### PR TITLE
plantuml: Add server usage support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 120

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
     "editor.defaultFormatter": "ms-python.autopep8",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Used 3rd party libraries which are not part of the standard Python package:
 | ------- | ----------- | ------- |
 | [trlc](https://github.com/bmw-software-engineering/trlc) | Treat Requirements Like Code | GPL-3.0 |
 | [toml](https://github.com/uiri/toml) | Parsing [TOML](https://en.wikipedia.org/wiki/TOML) | MIT |
+| [requests](https://github.com/psf/requests) | HTTP processing | Apache-2.0 |
 
 see also [requirements.txt](requirements.txt)
 

--- a/examples/plantuml/generate_to_markdown.bat
+++ b/examples/plantuml/generate_to_markdown.bat
@@ -17,12 +17,23 @@ rem You should have received a copy of the GNU General Public License along with
 rem If not, see <https://www.gnu.org/licenses/>.
 
 set OUT_PATH=./out
+
+rem Use either local jar file or plantuml server URL for rendering.
 set PLANTUML=plantuml.jar
+set PLANTUML=http://www.plantuml.com/plantuml
+set PLANTUML=https://puml.ww10ds423.synology.me
+
+rem Skip plantuml jar file download check if PLANTUML points to a server.
+echo %PLANTUML% | findstr /i "^http://" >nul
+if %errorlevel% equ 0 goto skip_download_plantuml
+echo %PLANTUML% | findstr /i "^https://" >nul
+if %errorlevel% equ 0 goto skip_download_plantuml
 
 if not exist "%PLANTUML%" (
     echo Download PlantUML java program...
     powershell -Command "Invoke-WebRequest https://github.com/plantuml/plantuml/releases/download/v1.2024.8/plantuml-1.2024.8.jar -OutFile %PLANTUML%"
 )
+:skip_download_plantuml
 
 pyTRLCConverter --source=. --out=%OUT_PATH% --project=req.py markdown
 

--- a/examples/plantuml/generate_to_markdown.bat
+++ b/examples/plantuml/generate_to_markdown.bat
@@ -20,8 +20,7 @@ set OUT_PATH=./out
 
 rem Use either local jar file or plantuml server URL for rendering.
 set PLANTUML=plantuml.jar
-set PLANTUML=http://www.plantuml.com/plantuml
-set PLANTUML=https://puml.ww10ds423.synology.me
+rem set PLANTUML=http://www.plantuml.com/plantuml
 
 rem Skip plantuml jar file download check if PLANTUML points to a server.
 echo %PLANTUML% | findstr /i "^http://" >nul

--- a/examples/plantuml/generate_to_markdown.sh
+++ b/examples/plantuml/generate_to_markdown.sh
@@ -17,11 +17,20 @@
 # If not, see <https://www.gnu.org/licenses/>.
 
 OUT_PATH=./out
-PLANTUML=plantuml.jar
 
-if [ ! -f "$PLANTUML" ]; then
-    echo "Download PlantUML java program..."
-    wget https://github.com/plantuml/plantuml/releases/download/v1.2024.8/plantuml-1.2024.8.jar -O $PLANTUML
+# Use either local jar file or plantuml server URL for rendering.
+export PLANTUML=plantuml.jar
+#export PLANTUML=http://www.plantuml.com/plantuml
+
+# check if given parameter is not a URL
+if ! [[ $PLANTUML =~ ^https?:// ]]
+then
+    # Assume local plantuml jar usage, download if not available.
+    if [ ! -f "$PLANTUML" ]
+    then
+        echo "Download PlantUML java program..."
+        wget https://github.com/plantuml/plantuml/releases/download/v1.2024.8/plantuml-1.2024.8.jar -O $PLANTUML
+    fi
 fi
 
 pyTRLCConverter --source=. --out=$OUT_PATH --project=req.py markdown

--- a/examples/plantuml/req.py
+++ b/examples/plantuml/req.py
@@ -117,8 +117,10 @@ def _print_diagram(fd, diagram):
         # ensure that the generated filename is as expected.
         expected_dst_path = os.path.join(_out_path, file_dst_path)
         if os.path.isfile(expected_dst_path) is False:
-            raise FileNotFoundError( \
-                f"{file_path} diagram name ('@startuml <name>') may differ from file name, expected {expected_dst_path}.")
+            raise FileNotFoundError(
+                f"{file_path} diagram name ('@startuml <name>') may differ from file name,"
+                 " expected {expected_dst_path}."
+            )
 
     else:
         # Copy diagram image file to output folder.

--- a/examples/plantuml/req.py
+++ b/examples/plantuml/req.py
@@ -118,7 +118,7 @@ def _print_diagram(fd, diagram):
         expected_dst_path = os.path.join(_out_path, file_dst_path)
         if os.path.isfile(expected_dst_path) is False:
             raise FileNotFoundError( \
-                f"{file_path} diagram name ('@startuml <name>') may differ from file name.")
+                f"{file_path} diagram name ('@startuml <name>') may differ from file name, expected {expected_dst_path}.")
 
     else:
         # Copy diagram image file to output folder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 
 dependencies = [
     "toml >= 0.10.2",
+    "requests >= 2.32.0",
     "trlc >= 2.0.1"
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+requests>=2.32.0
 toml>=0.10.2
 tomlkit>=0.13.2
 pylint>=3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+requests>=2.32.0
 toml==0.10.2
 trlc @ https://github.com/NewTec-GmbH/trlc/archive/refs/heads/main.zip

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -91,7 +91,7 @@ class PlantUML():
         if diagram_path.endswith(".plantuml") or \
             diagram_path.endswith(".puml") or \
             diagram_path.endswith(".wsd"):
-                is_valid = True
+            is_valid = True
 
         return is_valid
 

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -22,20 +22,41 @@
 # Imports **********************************************************************
 import os
 import subprocess
+import zlib
+import base64
+import urllib
+import urllib.parse
+import requests
+
+from pyTRLCConverter.log_verbose import log_verbose
 
 # Variables ********************************************************************
 
+# See https://plantuml.com/de/text-encoding for differences to base64 in URL encode.
+#
+BASE64_ENCODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+PLANTUML_ENCODE_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_"
+
 # Classes **********************************************************************
+
 
 class PlantUML():
     """PlantUML image generator.
     """
     def __init__(self) -> None:
+        self.server_url = None
         self._plantuml_jar = None
         self._working_directory = os.path.abspath(os.getcwd())
 
         if "PLANTUML" in os.environ:
-            self._plantuml_jar = os.environ["PLANTUML"]
+            plantuml_access = os.environ["PLANTUML"]
+            try:
+                if urllib.parse.urlparse(plantuml_access).scheme in ['http', 'https']:
+                    self.server_url = plantuml_access
+                else:
+                     self._plantuml_jar = os.environ["PLANTUML"]
+            except Exception as exc:
+                self._plantuml_jar = os.environ["PLANTUML"]
 
     def _get_absolute_path(self, path):
         """Get absolute path to the diagram.
@@ -73,8 +94,101 @@ class PlantUML():
 
         return is_valid
 
-    def generate(self, diagram_type, diagram_path, dst_path):
-        """Generate image.
+    def _make_server_url(self, diagram_type: str, diagram_path: str) -> str:
+        """Generate plantuml server GET URL for diagram data
+
+        Args:
+            server_url (str): URL of plantuml server (i.e. http://www.plantuml.com)
+            diagram_type (str): Diagram type, e.g. svg. See PlantUML -t options.
+            diagram_path (str): Path to the PlantUML diagram.
+
+        Raises:
+            FileNotFoundError: PlantUML diagram file not found.
+        """
+        # Read PlantUML diagram data
+        with open(diagram_path, 'r') as input_file:
+            diagram_string = input_file.read().encode('utf-8')
+
+        # Compress the data using deflate.
+        # Strib Zlib's 2 byte header and 4 byte checksum for raw deflate data.
+        compressed_data = zlib.compress(diagram_string)[2:-4]
+
+        # encode compressed data using base64
+        base64_encoded_data = base64.b64encode(compressed_data)
+
+        # Translate from base64 to plantuml encoding.
+        base64_to_puml_trans = bytes.maketrans(
+            BASE64_ENCODE_CHARS.encode('utf-8'),
+            PLANTUML_ENCODE_CHARS.encode('utf-8')
+        )
+        puml_encoded_data = base64_encoded_data.translate(base64_to_puml_trans).decode('utf-8')
+
+        # Create the URL for the PlantUML server
+        query_url = (
+            f"{self.server_url}/"
+            f"{diagram_type}/"
+            f"{urllib.parse.quote(puml_encoded_data)}"
+        )
+
+        return query_url
+
+    def generate(self, diagram_type: str, diagram_path: str, dst_path: str) -> None: 
+        """Generate plantuml image.
+
+        Args:
+            diagram_type (str): Diagram type, e.g. svg. See PlantUML -t options.
+            diagram_path (str): Path to the PlantUML diagram.
+            dst_path (str): Path to the destination of the generated image.
+
+        Raises:
+            FileNotFoundError: PlantUML java jar file not found in local mode
+            FileNotFoundError: PlantUML diagram file not found.
+            requests.exceptions.RequestException: Error during GET request to PlantUML server.
+            OSError: Destination path does not exist.
+        """
+        if self.server_url is not None:
+            self._generate_server(diagram_type, diagram_path, dst_path)
+        else:
+            self._generate_local(diagram_type, diagram_path, dst_path)
+
+    def _generate_server(self, diagram_type: str, diagram_path: str, dst_path: str) -> None:
+        """Generate image using a plantuml server
+
+        This is does not require java installed and is usually a lot faster
+        as no java startup time needed when using the plantuml.jar file.
+
+        Args:
+            diagram_type (str): Diagram type, e.g. svg. See PlantUML -t options.
+            diagram_path (str): Path to the PlantUML diagram.
+            dst_path (str): Path to the destination of the generated image.
+
+         Raises:
+            FileNotFoundError: PlantUML diagram file not found.
+            OSError: Destination path does not exist.
+            requests.exceptions.RequestException: Error during GET request to PlantUML server.
+        """
+        if not os.path.exists(dst_path):
+            os.makedirs(dst_path)
+
+        # Send a GET request to the PlantUML server
+        url = self._make_server_url(diagram_type, diagram_path)
+        log_verbose(f"Sending GET request {url}")
+        response = requests.get(url)
+
+        if response.status_code == 200:
+            # Save the response content in image file
+            output_file = os.path.splitext(os.path.basename(diagram_path))[0]
+            output_file += "." + diagram_type
+            output_file = os.path.join(dst_path, output_file)
+            with open(output_file, 'wb') as f:
+                f.write(response.content)
+
+            log_verbose(f"Diagram saved as {output_file}.")
+        else:
+            raise requests.exceptions.RequestException(f"{response.status_code} - {response.text}")
+
+    def _generate_local(self, diagram_type, diagram_path, dst_path):
+        """Generate image local call to plantuml.jar.
 
         Args:
             diagram_type (str): Diagram type, e.g. svg. See PlantUML -t options.
@@ -83,18 +197,18 @@ class PlantUML():
 
         Raises:
             FileNotFoundError: PlantUML java jar file not found.
+            OSError: Destination path does not exist.
         """
         if self._plantuml_jar is not None:
 
-            if 0 < len(dst_path):
-                if not os.path.exists(dst_path):
-                    os.makedirs(dst_path)
+            if not os.path.exists(dst_path):
+                os.makedirs(dst_path)
 
             plantuml_cmd = [
-                "java", \
-                "-jar", f"{self._plantuml_jar}", \
-                f"{diagram_path}", \
-                f"-t{diagram_type}", \
+                "java",
+                "-jar", f"{self._plantuml_jar}",
+                f"{diagram_path}",
+                f"-t{diagram_type}",
                 "-o", self._get_absolute_path(dst_path)
             ]
 

--- a/tests/test_plantuml.py
+++ b/tests/test_plantuml.py
@@ -1,0 +1,57 @@
+"""
+Unit tests for the PlantUML class in the pyTRLCConverter module.
+
+This file contains tests that verify the functionality of the PlantUML class,
+including the creation of server URLs for PlantUML diagrams.
+
+Fixtures:
+    plantuml_instance: Provides an instance of the PlantUML class with a mocked server URL.
+
+Tests:
+    test_make_server_url: Tests the _make_server_url method of the PlantUML class.
+"""
+import os
+import pytest
+from unittest.mock import patch, mock_open
+from pyTRLCConverter.plantuml import PlantUML
+
+# pylint: disable=W0212 # Access to a protected member
+
+
+@pytest.fixture
+def plantuml_instance():
+    """
+    Create an instance of PlantUML with a server URL.
+
+    This function temporarily sets the PLANTUML environment variable to
+    "http://plantuml.com/plantuml" and returns an instance of the PlantUML class.
+
+    Returns:
+        PlantUML: An instance of the PlantUML class configured to use the specified server URL.
+    """
+    with patch.dict(os.environ, {"PLANTUML": "http://plantuml.com/plantuml"}):
+        return PlantUML()
+
+
+def test_make_server_url(plantuml_instance: PlantUML):
+    """
+    Test the _make_server_url method of the PlantUML instance.
+    This test verifies that the _make_server_url method correctly generates
+    the server URL for a given diagram type and path. It mocks the content
+    of the diagram file and checks if the generated URL matches the expected URL.
+    Args:
+        plantuml (PlantUML): An instance of the PlantUML class.
+    Asserts:
+        The generated URL starts with the expected base URL.
+        The generated URL matches the expected URL.
+    """
+    diagram_type = "svg"
+    diagram_path = "test_diagram.puml"
+    expected_url = "http://plantuml.com/plantuml/svg/SoWkIImgAStDuNBCoKnELT2rKt3AJx9Iy4ZDoSddSaZDIm7A0G0%3D"
+
+    mock_diagram_content = "@startuml\nAlice -> Bob: Hello\n@enduml"
+    with patch("builtins.open", mock_open(read_data=mock_diagram_content)):
+        result_url = plantuml_instance._make_server_url(diagram_type, diagram_path)
+
+    assert result_url.startswith("http://plantuml.com/plantuml/svg/")
+    assert result_url == expected_url

--- a/tools/req2markdown/req2markdown.py
+++ b/tools/req2markdown/req2markdown.py
@@ -101,8 +101,9 @@ def _print_diagram(fd, diagram):
             raise FileNotFoundError(f"{file_path} not found.")
 
     if plantuml_generator.is_plantuml_file(file_path):
-        plantuml_generator.generate(image_format, full_file_path, _out_path)
 
+        plantuml_generator.generate(image_format, full_file_path, _out_path)
+        
         file_dst_path = os.path.basename(full_file_path)
         file_dst_path = os.path.splitext(file_dst_path)[0]
         file_dst_path += "." + image_format

--- a/tools/req2markdown/req2markdown.py
+++ b/tools/req2markdown/req2markdown.py
@@ -114,8 +114,10 @@ def _print_diagram(fd, diagram):
         # ensure that the generated filename is as expected.
         expected_dst_path = os.path.join(_out_path, file_dst_path)
         if os.path.isfile(expected_dst_path) is False:
-            raise FileNotFoundError( \
-                f"{file_path} diagram name ('@startuml <name>') may differ from file name.")
+            raise FileNotFoundError(
+                f"{file_path} diagram name ('@startuml <name>') may differ from file name,"
+                 " expected {expected_dst_path}."
+            )
 
     else:
         # Copy diagram image file to output folder.


### PR DESCRIPTION
Use plantuml server if environment variable PLANTUML is a URL.
Otherwise treat it as a local plantuml.jar path.