### PR TITLE
fix issue: Test /tools/* after refactoring #19

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,6 @@
                 "-o=./out/sw-requirements/markdown",
                 "--verbose",
                 "--project=req2markdown",
-                "--help",
                 "markdown",
             ]
         },

--- a/doc/sw-requirements/sw_req.trlc
+++ b/doc/sw-requirements/sw_req.trlc
@@ -1,6 +1,12 @@
 package SwRequirements
 
+import Generic
+
 section "pyTRLCConverter" {
+
+    Generic.Info sw_req_info_about_sw_req {
+        description = "This file contains the software requirements for the pyTRLCConverter tool."
+    }
 
     section "Software Requirements" {
 

--- a/doc/sw-test/sw_test.trlc
+++ b/doc/sw-test/sw_test.trlc
@@ -5,7 +5,7 @@ import SwRequirements
 
 section "SW-Test" {
 
-    Generic.Info sw_req_info_about_sw_req {
+    Generic.Info sw_test_info_about_sw_test {
         description = "This file contains the software test cases for the pyTRLCConverter tool."
     }
 

--- a/doc/sw-test/sw_test.trlc
+++ b/doc/sw-test/sw_test.trlc
@@ -1,7 +1,13 @@
 package SwTests
+
+import Generic
 import SwRequirements
 
 section "SW-Test" {
+
+    Generic.Info sw_req_info_about_sw_req {
+        description = "This file contains the software test cases for the pyTRLCConverter tool."
+    }
 
     SwTestCase tc1 {
         description = "Test"

--- a/src/pyTRLCConverter/dump_converter.py
+++ b/src/pyTRLCConverter/dump_converter.py
@@ -28,7 +28,7 @@ from pyTRLCConverter.trlc_helper import Record_Object
 
 class DumpConverter(BaseConverter):
     #lobster-trace: Dump.sw_req_ascii_conversion
-    """Simple converter implemention that just dumps all items.
+    """Simple converter implementation that just dumps all items.
     """
 
     @staticmethod

--- a/tools/req2docx/custom_docx.py
+++ b/tools/req2docx/custom_docx.py
@@ -81,7 +81,7 @@ class CustomDocxConverter(DocxConverter):
             Ret: Status
         """
         attributes = record.to_python_dict()
-        if "text" in attributes:
+        if "description" in attributes:
             self._docx.add_paragraph(self._get_attribute(record, "description"))
 
         return Ret.OK
@@ -124,7 +124,7 @@ class CustomDocxConverter(DocxConverter):
             p.paragraph_format.alignment = docx.enum.text.WD_ALIGN_PARAGRAPH.CENTER
             run = p.add_run()
             run.add_picture(expected_dst_path, width=docx.shared.Inches(6))
-            run.add_text(f"Figure {self._img_counter} {self._get_attribute(record, "caption")}")
+            run.add_text(f"Figure {self._img_counter} {self._get_attribute(record, 'caption')}")
 
             result = Ret.OK
 

--- a/tools/req2docx/req2docx.bat
+++ b/tools/req2docx/req2docx.bat
@@ -35,7 +35,7 @@ if not exist %SWE_REQ_OUT_DIR% (
 )
 
 echo Generate software requirements ...
-pyTRLCConverter --source=..\..\doc\sw-requirements --source=..\..\doc\models -o=%SWE_REQ_OUT_DIR% %SWE_REQ_OUT_FORMAT%
+pyTRLCConverter --source=..\..\doc\sw-requirements --source=..\..\doc\models --verbose -o=%SWE_REQ_OUT_DIR% --project=custom_docx %SWE_REQ_OUT_FORMAT% --template ACME.docx
 
 if errorlevel 1 (
     pause

--- a/tools/req2docx/req2docx.sh
+++ b/tools/req2docx/req2docx.sh
@@ -38,7 +38,7 @@ if [ ! -d "$SWE_REQ_OUT_DIR" ]; then
 fi
 
 echo "Generate software requirements ..."
-pyTRLCConverter --source=../../doc/sw-requirements --source=../../doc/models --verbose -o="$SWE_REQ_OUT_DIR"  --project=custom_docx  --verbose "$SWE_REQ_OUT_FORMAT" --template ACME.docx
+pyTRLCConverter --source=../../doc/sw-requirements --source=../../doc/models --verbose -o="$SWE_REQ_OUT_DIR"  --project=custom_docx  "$SWE_REQ_OUT_FORMAT" --template ACME.docx
 
 if [ $? -ne 0 ]; then
     read -p "Press any key to continue..."

--- a/tools/req2markdown/req2markdown.bat
+++ b/tools/req2markdown/req2markdown.bat
@@ -35,7 +35,7 @@ if not exist %SWE_REQ_OUT_DIR% (
 )
 
 echo Generate software requirements ...
-pyTRLCConverter --source=..\..\doc\sw-requirements --source=..\..\doc\models -o=%SWE_REQ_OUT_DIR% -p=req2markdown %SWE_REQ_OUT_FORMAT%
+pyTRLCConverter --source=..\..\doc\sw-requirements --source=..\..\doc\models -o=%SWE_REQ_OUT_DIR% --verbose -p=req2markdown %SWE_REQ_OUT_FORMAT%
 
 if errorlevel 1 (
     pause

--- a/tools/req2markdown/req2markdown.py
+++ b/tools/req2markdown/req2markdown.py
@@ -166,7 +166,7 @@ class CustomMarkDownConverter(MarkdownConverter):
 
         markdown_info = self.markdown_escape(description)
         self._fd.write(markdown_info)
-        self._fd.write("\n")
+        self._fd.write("\n\n")
 
     def _print_sw_req(self, sw_req: Record_Object, level: int) -> None:
         """Prints the software requirement.

--- a/tools/test2markdown/test2markdown.bat
+++ b/tools/test2markdown/test2markdown.bat
@@ -35,7 +35,7 @@ if not exist %SW_TEST_OUT_DIR% (
 )
 
 echo Generate software tests ...
-pyTRLCConverter --source=..\..\doc\sw-requirements --source=..\..\doc\sw-test --exclude=..\..\doc\sw-requirements --source=..\..\doc\models -o=%SW_TEST_OUT_DIR% --project=test2markdown %SW_TEST_OUT_FORMAT%
+pyTRLCConverter --source=..\..\doc\sw-requirements --source=..\..\doc\sw-test --exclude=..\..\doc\sw-requirements --source=..\..\doc\models -o=%SW_TEST_OUT_DIR% --verbose --project=test2markdown %SW_TEST_OUT_FORMAT%
 
 if errorlevel 1 (
     pause

--- a/tools/test2markdown/test2markdown.py
+++ b/tools/test2markdown/test2markdown.py
@@ -160,7 +160,7 @@ class CustomMarkDownConverter(MarkdownConverter):
 
         markdown_info = self.markdown_escape(description)
         self._fd.write(markdown_info)
-        self._fd.write("\n")
+        self._fd.write("\n\n")
 
     def _print_sw_test_case(self, sw_test_case: Record_Object, level: int) -> None:
         """Prints the software test case.

--- a/tools/test2markdown/test2markdown.sh
+++ b/tools/test2markdown/test2markdown.sh
@@ -36,7 +36,7 @@ if [ ! -d "$SW_TEST_OUT_DIR" ]; then
 fi
 
 echo "Generate software test cases ..."
-pyTRLCConverter --source=../../doc/sw-requirements --source=../../doc/sw-test --exclude=../../doc/sw-requirements --source=../../doc/models -o="$SW_TEST_OUT_DIR" --project=test2markdown "$SW_TEST_OUT_FORMAT"
+pyTRLCConverter --source=../../doc/sw-requirements --source=../../doc/sw-test --exclude=../../doc/sw-requirements --source=../../doc/models -o="$SW_TEST_OUT_DIR" --verbose --project=test2markdown "$SW_TEST_OUT_FORMAT"
 
 if [ $? -ne 0 ]; then
     read -p "Press any key to continue..."


### PR DESCRIPTION
## Generic

* Added Info text at the top of sw_req.trl to use (test) this record type.

##  tools/req2docx

* Windows power-shell script: missing --project option (and --verbose)
* custom_docx.py : fix f-string syntax error ( nested " quotes )
* custom_docx.py: fix info attrribute usage (was renamed  from text to description)

## tools/req2markdown

* Windows power-shell script: missing --verbose
* req2markdown.py: add a second newline output for Info records to have a seperator.

## tools/test2markdown

* Tool working in the meantime ( -> PR  #20 )
* added "--verbose" option to align with other tools
 * test2markdown.py: add a second newline output for Info records to have a separator.

## tools/sphinx
* sphinx crashes in context with plantuml. No idea why, maybe setup issue.