### PR TITLE
Rework dynamic argument parsing.

### DIFF
--- a/src/pyTRLCConverter/__main__.py
+++ b/src/pyTRLCConverter/__main__.py
@@ -58,7 +58,7 @@ BUILD_IN_CONVERTER_LIST = [
 
 def _extend_description() -> str:
     """Manually extend the description with the positional arguments for the subcommands.
-    
+
     Returns:
         str: Formatted description that includes the built in commands."""
     description = PROG_DESC + "\n\n"
@@ -164,7 +164,7 @@ def main() -> int:
     parsed_args, remaining_args = initial_parser.parse_known_args()
 
     # Create parser for dynamic project specific arguments.
-    command_parser = argparse.ArgumentParser()
+    command_parser = argparse.ArgumentParser(prog=PROG_NAME + " command parser:")
     args_sub_parser = command_parser.add_subparsers(required=True)
 
     # Check if a project specific converter is given and load it.


### PR DESCRIPTION
Rework proposal for issue #17.

Do not merge.
This PR is intended for comparison and discussion.

Pros:

* Manual argument parsing can be removed.
* _get_project_converter can be massively simplified.
* argparse handles all parsing and one single args Namespace is created.

Cons:

* 2 parsers exist, one for the fixed arguments (initial__parser) and one for the subcommands and dynamic args (command_parser).
* initial_parser --help output would loose the information about the subcommands. So the description has to be manually extended.

OK:
* Manually extending the --help output allows to showcase that custom parsers can introduce new subcommands.
* If somebody applies a custom parser, it can reasonably be expected they know the parsers subcommnad.
* Usage output of the command parser will show available subcommands directly, but omit fixed arguments.
