### PR TITLE
Converter API: Use classmethod for register

### DIFF
--- a/src/pyTRLCConverter/__main__.py
+++ b/src/pyTRLCConverter/__main__.py
@@ -155,14 +155,15 @@ def main() -> int:
     project_converter = _get_project_converter()
 
     if project_converter is not None:
-        project_converter.register(args_sub_parser, project_converter)
+        print(project_converter)
+        project_converter.register(args_sub_parser)
         project_converter_cmd = project_converter.get_subcommand()
 
     # Load the built-in converters unless a project converter is replacing built-in.
     # lobster-trace: SwRequirements.sw_req_no_prj_spec
     for converter in BUILD_IN_CONVERTER_LIST:
         if converter.get_subcommand() != project_converter_cmd:
-            converter.register(args_sub_parser, converter)
+            converter.register(args_sub_parser)
 
 
     args = args_parser.parse_args()

--- a/src/pyTRLCConverter/__main__.py
+++ b/src/pyTRLCConverter/__main__.py
@@ -155,7 +155,6 @@ def main() -> int:
     project_converter = _get_project_converter()
 
     if project_converter is not None:
-        print(project_converter)
         project_converter.register(args_sub_parser)
         project_converter_cmd = project_converter.get_subcommand()
 

--- a/src/pyTRLCConverter/abstract_converter.py
+++ b/src/pyTRLCConverter/abstract_converter.py
@@ -32,13 +32,12 @@ class AbstractConverter(ABC):
     # lobster-trace: SwRequirements.sw_req_prj_spec_interface
     """Abstract converter interface.
     """
-    @staticmethod
-    def register(args_parser, cls: type) -> None:
+    @classmethod
+    def register(cls, args_parser) -> None:
         """Register converter specific argument parser.
 
         Args:
             args_parser (object): Argument parser
-            cls (type):  The class type to use
         """
         raise NotImplementedError
 

--- a/src/pyTRLCConverter/base_converter.py
+++ b/src/pyTRLCConverter/base_converter.py
@@ -49,13 +49,12 @@ class BaseConverter(AbstractConverter):
         """
         self._args = args
 
-    @staticmethod
-    def register(args_parser, cls: type) -> None:
+    @classmethod
+    def register(cls, args_parser) -> None:
         """Register converter specific argument parser.
 
         Args:
             args_parser (object): Argument parser
-            cls (type): The class type to register
         """
         BaseConverter._parser = args_parser.add_parser(
             cls.get_subcommand(),

--- a/src/pyTRLCConverter/docx_converter.py
+++ b/src/pyTRLCConverter/docx_converter.py
@@ -68,16 +68,16 @@ class DocxConverter(BaseConverter):
         """
         return "Convert into docx format."
 
-    @staticmethod
-    def register(args_parser, cls : type) -> None:
+    @classmethod
+    def register(cls, args_parser) -> None:
         # lobster-trace: SwRequirements.sw_req_destination_format
         """Register converter specific argument parser.
 
         Args:
             args_parser (object): Argument parser
-            cls (type): The class type to register
         """
-        BaseConverter.register(args_parser, cls)
+        super().register(args_parser)
+
         BaseConverter._parser.add_argument(
             "-t",
             "--template",


### PR DESCRIPTION
Python offers classmethod in addition to staticmethod.
Use it to simplify call to register.