### PR TITLE
Bugfix/docx table style

### DIFF
--- a/src/pyTRLCConverter/docx_converter.py
+++ b/src/pyTRLCConverter/docx_converter.py
@@ -58,7 +58,8 @@ class DocxConverter(BaseConverter):
         self._docx = docx.Document(docx=args.template)
 
         # Ensure default table style is present in the document.
-        self._docx.styles.add_style('Table Grid', docx.enum.style.WD_STYLE_TYPE.TABLE, builtin=True)
+        if not 'Table Grid' in self._docx.styles:
+            self._docx.styles.add_style('Table Grid', docx.enum.style.WD_STYLE_TYPE.TABLE, builtin=True)
 
     @staticmethod
     def get_subcommand() -> str:

--- a/src/pyTRLCConverter/docx_converter.py
+++ b/src/pyTRLCConverter/docx_converter.py
@@ -23,6 +23,7 @@
 import os
 from typing import Optional
 import docx
+import docx.enum
 from pyTRLCConverter.base_converter import BaseConverter
 from pyTRLCConverter.log_verbose import log_verbose
 from pyTRLCConverter.ret import Ret
@@ -55,6 +56,9 @@ class DocxConverter(BaseConverter):
             log_verbose(f"Loading template file {args.template}.")
 
         self._docx = docx.Document(docx=args.template)
+
+        # Ensure default table style is present in the document.
+        self._docx.styles.add_style('Table Grid', docx.enum.style.WD_STYLE_TYPE.TABLE, builtin=True)
 
     @staticmethod
     def get_subcommand() -> str:

--- a/src/pyTRLCConverter/docx_converter.py
+++ b/src/pyTRLCConverter/docx_converter.py
@@ -23,7 +23,6 @@
 import os
 from typing import Optional
 import docx
-import docx.enum
 from pyTRLCConverter.base_converter import BaseConverter
 from pyTRLCConverter.log_verbose import log_verbose
 from pyTRLCConverter.ret import Ret


### PR DESCRIPTION
A new docx file, that never included a table would not contain the default table style.
Using this file as a template for the docx_converter would result in multiple errors.
(Dont actually know how the resulting document looked).

Now the default table style is added if it is missing from the template document,