### PR TITLE
Restructured Text: Use figure (with caption text) instead of image for graphics.

### DIFF
--- a/src/pyTRLCConverter/rst_converter.py
+++ b/src/pyTRLCConverter/rst_converter.py
@@ -722,7 +722,12 @@ class RstConverter(BaseConverter):
         # Allowed are absolute and relative to source paths.
         diagram_file_name = os.path.normpath(diagram_file_name)
 
-        return f".. image:: {diagram_file_name}\n    :alt: {diagram_caption_raw}\n"
+        result =  f".. figure:: {diagram_file_name}\n    :alt: {diagram_caption_raw}\n"
+
+        if diagram_caption_raw:
+            result += f"\n    {diagram_caption_raw}\n"
+
+        return result
 
     @staticmethod
     def rst_role(text: str, role: str, escape: bool = True) -> str:

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -297,26 +297,26 @@ def test_tc_rst_image(record_property, tmp_path):
     assert rst_converter.rst_create_diagram_link(
         f"{diagram_path}",
         "Caption") == \
-        f".. image:: {os.path.normpath(diagram_path)}\n    :alt: Caption\n"
+        f".. figure:: {os.path.normpath(diagram_path)}\n    :alt: Caption\n\n    Caption\n"
 
     diagram_path = "diagram.png"
     assert rst_converter.rst_create_diagram_link(
         f"{diagram_path}",
         "Caption") == \
-        f".. image:: {os.path.normpath(diagram_path)}\n    :alt: Caption\n"
+        f".. figure:: {os.path.normpath(diagram_path)}\n    :alt: Caption\n\n    Caption\n"
 
     diagram_path = "./graph.jpg"
     assert rst_converter.rst_create_diagram_link(
         "./graph.jpg",
         "Caption with special characters!") == \
-        f".. image:: {os.path.normpath(diagram_path)}\n    :alt: Caption with special characters\\!\n"
+        f".. figure:: {os.path.normpath(diagram_path)}\n    :alt: Caption with special characters\\!\n\n    Caption with special characters\\!\n"
 
     diagram_path = "./I/am/nested.png"
     assert rst_converter.rst_create_diagram_link(
         "./I/am/nested.png",
         "Caption with special characters!",
         escape=False) == \
-        f".. image:: {os.path.normpath(diagram_path)}\n    :alt: Caption with special characters!\n"
+        f".. figure:: {os.path.normpath(diagram_path)}\n    :alt: Caption with special characters!\n\n    Caption with special characters!\n"
 
 def test_tc_rst_role(record_property, tmp_path):
     # lobster-trace: SwTests.tc_rst_role

--- a/tools/sphinx/source/_static/custom.css
+++ b/tools/sphinx/source/_static/custom.css
@@ -24,3 +24,8 @@ p.admonition-title {
 .green {
     color: green;
 }
+
+span.caption-text {
+    display: block;
+    text-align: center;
+}


### PR DESCRIPTION
address #55