### PR TITLE
License changed to GPL-3.0-or-later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 authors = [
     { name = "Andreas Merkle", email = "andreas.merkle@newtec.de" }
 ]
-license = "GPL-3.0-only"
+license = "GPL-3.0-or-later"
 classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Use GPL-3.0-or-later because the GPL-3.0-only hinders the integration and distribution of combined works.

Please note that the failing checks are not triggered by this PR. They will be fixed in a separate PR with the update to bmw-lobster 1.0.0