### PR TITLE
Bugfix in case excluded paths are not defined by arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyTRLCConverter"
-version = "1.0.2"
+version = "1.0.3"
 description = "Supports the conversion from TRLC files to other formats."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pyTRLCConverter/markdown_converter.py
+++ b/src/pyTRLCConverter/markdown_converter.py
@@ -55,8 +55,8 @@ class MarkdownConverter(BaseConverter):
         # The path to the given output folder.
         self._out_path = args.out
 
-        # The excluded files in normalized form.
-        self._excluded_files = []
+        # The excluded paths in normalized form.
+        self._excluded_paths = []
 
         if args.exclude is not None:
             self._excluded_paths = [os.path.normpath(path) for path in args.exclude]

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -423,6 +423,51 @@ def test_tc_markdown_single_doc_exclude(record_property, capsys, monkeypatch, tm
         assert lines[6] == r"| description | Test description |" + "\n"
         assert lines[7] == r"| link | [Requirements\.req\_id\_2](single_req_with_section.md#req_id_2) |" + "\n"
 
+def test_tc_markdown_single_doc_exclude_none(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_cli_exclude
+    """
+    The software shall support excluding nothing when no exclude arguments are given.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Path): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_cli_exclude")
+
+    # Mock program arguments to specify an output folder.
+    output_file_name = "myReq.md"
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils",
+        "--out", str(tmp_path),
+        "markdown",
+        "--single-document",
+        "--name", output_file_name
+    ])
+
+    # Expect the program to run without any exceptions.
+    main()
+
+    # Capture stdout and stderr.
+    captured = capsys.readouterr()
+    # Check that no errors were reported.
+    assert captured.err == ""
+
+    # Verify
+    with open(os.path.join(tmp_path, output_file_name), "r", encoding='utf-8') as generated_md:
+        lines = generated_md.readlines()
+        assert lines[0] == "# Specification\n"
+        assert lines[1] == "\n"
+        assert lines[2] == r"### req\_id\_1" + "\n"
+        assert lines[3] == "\n"
+        assert lines[4] == r"| Attribute Name | Attribute Value |" + "\n"
+        assert lines[5] == r"| -------------- | --------------- |" + "\n"
+        assert lines[6] == r"| description | Test description |" + "\n"
+        assert lines[7] == r"| link | N/A |" + "\n"
+        # Not all lines are checked.
+
 def test_tc_markdown_multi_doc(record_property, capsys, monkeypatch, tmp_path):
     # lobster-trace: SwTests.tc_markdown_multi_doc
     """


### PR DESCRIPTION
The MarkdownConverter defined in the constructor _excluded_paths with the wrong name. That caused an exception in single document mode without given excluded paths.

#77