### PR TITLE
Fix TypeError in pyTRLCConverter.exe execution

### DIFF
--- a/src/pyTRLCConverter/version.py
+++ b/src/pyTRLCConverter/version.py
@@ -79,12 +79,19 @@ def init_from_toml():
     toml_file = resource_path("pyproject.toml")
     data = toml.load(toml_file)
 
+    # Handle license as either a string or a dictionary
+    license_field = data["project"]["license"]
+    if isinstance(license_field, dict):
+        license_text = license_field.get("text", "???")
+    else:
+        license_text = license_field
+
     return \
         data["project"]["version"], \
         data["project"]["authors"][0]["name"], \
         data["project"]["authors"][0]["email"], \
         data["project"]["urls"]["repository"], \
-        data["project"]["license"]["text"]
+        license_text
 
 # Main *************************************************************************
 


### PR DESCRIPTION
Resolve a TypeError that occurred when calling pyTRLCConverter.exe by handling the license field correctly, accommodating both string and dictionary formats.

Fixes #101