### PR TITLE
Fix invalid rules in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,30 +1,27 @@
-# Default behaviour
-*               text=crlf
-
 # All text files are CRLF
-*.txt		    text eol=crlf
-*.h 		    text eol=crlf
-*.c 		    text eol=crlf
-*.cpp 		    text eol=crlf
-*.hpp 		    text eol=crlf
-*.py 		    text eol=crlf
-*.json 		    text eol=crlf
-*.md 		    text eol=crlf
-*.puml 		    text eol=crlf
-*.plantuml 		text eol=crlf
-*.ini 		    text eol=crlf
-*.bat 		    text eol=crlf
-*.yml 		    text eol=crlf
-*.toml 		    text eol=crlf
-*.cfg 		    text eol=crlf
+*.bat         text eol=crlf
+*.c           text eol=crlf
+*.cfg         text eol=crlf
+*.cpp         text eol=crlf
+*.h           text eol=crlf
+*.hpp         text eol=crlf
+*.ini         text eol=crlf
+*.json        text eol=crlf
+*.md          text eol=crlf
+*.plantuml    text eol=crlf
+*.puml        text eol=crlf
+*.py          text eol=crlf
+*.toml        text eol=crlf
+*.txt         text eol=crlf
+*.yaml        text eol=crlf
+*.yml         text eol=crlf
 
-# Linux shell scripts should be auto, to be LF on linux host
-*.bash          text eol=auto
-*.sh            text eol=auto
-*.zsh           text eol=auto
+# Linux shell scripts should be LF
+*.bash        text eol=lf
+*.sh          text eol=lf
+*.zsh         text eol=lf
 
 # Images should be treated as binary
-*.png           binary
-*.jpg           binary
-*.jpeg          binary
-*.svg           binary
+*.jpeg        binary
+*.jpg         binary
+*.png         binary


### PR DESCRIPTION
Corrected invalid rules in the .gitattributes file and add support for YAML files. Adjustments include resolving mixed tab/space issues and sorting the lines.

The invalid default behavior ```* text=crlf``` has been removed completely. Meaning that any unlisted file type now has no rule. On main it was also invalid/ignored, so behavior is the same. This goes with our recommendation to have 
```
git config --global core.autocrlf false
```
The invalid eol=auto for Linux shell scripts has been fixed to use eol=lf.

Fixes #104