### PR TITLE
GitHub Flavored Markdown support added.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ jobs:
           pip install -r requirements-dev.txt
           pip install "pyTRLCConverter>=2.0.0"
 
-      - name: Analysing the requirements and test cases with TRLC
+      - name: Analysing all TRLC releated elements
         run: |
-          trlc ./trlc/model ./trlc/swe-req ./trlc/swe-test
+          trlc ./trlc
 
       - name: Prepare test report
         run: |
@@ -55,12 +55,12 @@ jobs:
 
       - name: Build tracing report
         run: |
-            pushd ./tools/traceReport
-            chmod +x make.sh
-            ./make.sh online
-            rm -f ./out/*-lobster.json
-            popd
-  
+          pushd ./tools/traceReport
+          chmod +x make.sh
+          ./make.sh online
+          rm -f ./out/*-lobster.json
+          popd
+
       - name: Upload tracing report
         uses: actions/upload-artifact@v4
         with:
@@ -93,7 +93,7 @@ jobs:
 
       - name: Analysing the code with pylint
         run: |
-          pylint ./src ./tools
+          pylint ./src ./tests ./tools
 
   test:
     # The type of runner that the job will run on.
@@ -122,7 +122,7 @@ jobs:
       - name: Test and create coverage report
         run: |
           pytest tests -v --cov=./src --cov-report=term
-  
+
 # Uncomment this section to generate a html coverage report
 #      - name: Test and create coverage report
 #        run: |

--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ See the [example](./examples/simple_req_translation/) for more information.
 
 When requirements include lists or need bold/italic emphasis, TRLC currently supports plain text only. pyTRLCConverter lets you write requirement descriptions in Markdown and converts them to the chosen target format (e.g., reStructuredText). To enable this, you must explicitly specify in a JSON configuration which attribute contains Markdown-formatted content.
 
+Two Markdown specifications are supported:
+
+- "md": [CommonMark's spec v0.31.2](https://spec.commonmark.org/0.31.2/)
+- "gfm": [GitHub Flavored Markdown spec v0.29-gfm](https://github.github.com/gfm)
+
+Supported by the formats:
+
+| Format           | CommonMark               | GitHub Flavored          |
+| ---------------- | ------------------------ | ------------------------ |
+| docx             | X                        | Output as string literal |
+| dump             | Output as string literal | Output as string literal |
+| markdown         | X                        | X                        |
+| reStructuredText | X                        | X                        |
+
 Configuration example:
 
 ```json
@@ -261,14 +275,14 @@ Tools used for development or automations, see [Tools](./tools/README.md).
 
 Used 3rd party libraries which are not part of the standard Python package:
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [PlantUML](https://github.com/plantuml/plantuml) | Generate UML diagrams. | GPL-3.0 |
-| [python-docx](https://github.com/python-openxml/python-docx) | Creation of Microsoft Word 2007+ (.docx) files. | MIT |
-| [requests](https://github.com/psf/requests) | HTTP processing | Apache-2.0 |
-| [sphinx](https://github.com/sphinx-doc/sphinx) | Using Sphinx for documentation deployment. | BSD |
-| [toml](https://github.com/uiri/toml) | Parsing [TOML](https://en.wikipedia.org/wiki/TOML) | MIT |
-| [trlc](https://github.com/bmw-software-engineering/trlc) | Treat Requirements Like Code | GPL-3.0 |
+| Library                                                      | Description                                        | License    |
+| ------------------------------------------------------------ | -------------------------------------------------- | ---------- |
+| [PlantUML](https://github.com/plantuml/plantuml)             | Generate UML diagrams.                             | GPL-3.0    |
+| [python-docx](https://github.com/python-openxml/python-docx) | Creation of Microsoft Word 2007+ (.docx) files.    | MIT        |
+| [requests](https://github.com/psf/requests)                  | HTTP processing                                    | Apache-2.0 |
+| [sphinx](https://github.com/sphinx-doc/sphinx)               | Using Sphinx for documentation deployment.         | BSD        |
+| [toml](https://github.com/uiri/toml)                         | Parsing [TOML](https://en.wikipedia.org/wiki/TOML) | MIT        |
+| [trlc](https://github.com/bmw-software-engineering/trlc)     | Treat Requirements Like Code                       | GPL-3.0    |
 
 see also [requirements.txt](requirements.txt)
 

--- a/doc/architecture/components/comp_rst_converter.puml
+++ b/doc/architecture/components/comp_rst_converter.puml
@@ -33,7 +33,11 @@ package "Dependencies" {
         + walk(ast: Any) : None
     }
 
-    class RSTRenderer {
+    class Md2RstRenderer {
+        + render(ast: Any) : str
+    }
+
+    class Gfm2RstRenderer {
         + render(ast: Any) : str
     }
 
@@ -47,7 +51,8 @@ package "Dependencies" {
 ' Relationships
 RstConverter ..> trlc
 RstConverter ..> TrlcAstWalker
-RstConverter ..> RSTRenderer
+RstConverter ..> Md2RstRenderer
+RstConverter ..> Gfm2RstRenderer
 RstConverter ..> marko
 
 @enduml

--- a/src/pyTRLCConverter/docx_converter.py
+++ b/src/pyTRLCConverter/docx_converter.py
@@ -31,7 +31,7 @@ from docx.enum.style import WD_STYLE_TYPE
 from marko import Markdown
 from trlc.ast import Implicit_Null, Record_Object, Record_Reference, String_Literal, Array_Aggregate, Expression
 from pyTRLCConverter.base_converter import BaseConverter
-from pyTRLCConverter.marko.docx_renderer import DocxRenderer
+from pyTRLCConverter.marko.md2docx_renderer import Md2DocxRenderer
 from pyTRLCConverter.ret import Ret
 from pyTRLCConverter.trlc_helper import TrlcAstWalker
 from pyTRLCConverter.logger import log_verbose
@@ -355,10 +355,10 @@ class DocxConverter(BaseConverter):
         """
         assert self._block_item_container is not None
 
-        # If the attribute is marked as markdown format, convert it.
+        # If the attribute is marked as CommonMark Markdown format, convert it.
         if self._render_cfg.is_format_md(package_name, type_name, attribute_name) is True:
-            DocxRenderer.block_item_container = self._block_item_container
-            markdown = Markdown(renderer=DocxRenderer)
+            Md2DocxRenderer.block_item_container = self._block_item_container
+            markdown = Markdown(renderer=Md2DocxRenderer)
             markdown.convert(attribute_value)
         else:
             self._block_item_container.add_paragraph(attribute_value)

--- a/src/pyTRLCConverter/markdown_converter.py
+++ b/src/pyTRLCConverter/markdown_converter.py
@@ -424,6 +424,7 @@ class MarkdownConverter(BaseConverter):
     def _on_string_literal(self, string_literal: String_Literal) -> str:
         # lobster-trace: SwRequirements.sw_req_markdown_string_format
         # lobster-trace: SwRequirements.sw_req_markdown_render_md
+        # lobster-trace: SwRequirements.sw_req_markdown_render_gfm
         """
         Process the given string literal value.
 
@@ -536,6 +537,7 @@ class MarkdownConverter(BaseConverter):
     def _render(self, package_name: str, type_name: str, attribute_name: str, attribute_value: str) -> str:
         # lobster-trace: SwRequirements.sw_req_markdown_string_format
         # lobster-trace: SwRequirements.sw_req_markdown_render_md
+        # lobster-trace: SwRequirements.sw_req_markdown_render_gfm
         """Render the attribute value depened on its format.
 
         Args:
@@ -550,7 +552,9 @@ class MarkdownConverter(BaseConverter):
         result = attribute_value
 
         # If the attribute value is not already in Markdown format, it will be escaped.
-        if self._render_cfg.is_format_md(package_name, type_name, attribute_name) is False:
+        if self._render_cfg.is_format_md(package_name, type_name, attribute_name) is False and \
+            self._render_cfg.is_format_gfm(package_name, type_name, attribute_name) is False:
+
             result = self.markdown_escape(attribute_value)
             result = self.markdown_lf2soft_return(result)
 

--- a/src/pyTRLCConverter/marko/gfm2rst_renderer.py
+++ b/src/pyTRLCConverter/marko/gfm2rst_renderer.py
@@ -1,0 +1,204 @@
+"""reStructuredText renderer for Marko.
+    It is used to convert GitHub Flavored Markdown AST to reStructuredText format.
+
+    Author: Andreas Merkle (andreas.merkle@newtec.de)
+"""
+
+# pyTRLCConverter - A tool to convert TRLC files to specific formats.
+# Copyright (c) 2024 - 2026 NewTec GmbH
+#
+# This file is part of pyTRLCConverter program.
+#
+# The pyTRLCConverter program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# The pyTRLCConverter program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with pyTRLCConverter.
+# If not, see <https://www.gnu.org/licenses/>.
+
+# Imports **********************************************************************
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Any, cast
+from pyTRLCConverter.marko.md2rst_renderer import Md2RstRenderer
+
+if TYPE_CHECKING:
+    from . import block, inline
+
+# Variables ********************************************************************
+
+# Classes **********************************************************************
+
+# pylint: disable-next=too-many-public-methods
+class Gfm2RstRenderer(Md2RstRenderer):
+    # lobster-trace: SwRequirements.sw_req_rst_render_gfm
+    """
+    Renderer for reStructuredText output.
+    It is used to convert GitHub Flavored Markdown to reStructuredText format.
+    """
+
+    # Inherit all CommonMark rendering behavior from Md2RstRenderer and override only GFM additions.
+
+    def render_list_item(self, element: block.ListItem, marker="-") -> str:
+        """
+        Renders a list item element.
+
+        Args:
+            element (block.ListItem): The list item element to render.
+            marker (str, optional): The marker to use for the list item. Defaults to "*".
+
+        Returns:
+            str: The rendered list item as a string.
+        """
+        indent = 2
+        content = self.render_children(element)
+
+        # GitHub Flavored Markdown task-list items expose a "checked" flag in the paragraph node.
+        # Prefix the rendered item text to preserve the task state in reStructuredText output.
+        if 0 < len(element.children):
+            first_child = element.children[0]
+            checked = getattr(first_child, "checked", None)
+            if checked is True:
+                content = "[x] " + content.lstrip()
+            elif checked is False:
+                content = "[ ] " + content.lstrip()
+
+        return f"{' ' * indent * (self._list_indent_level - 1)}{marker} {content}"
+
+    def render_table(self, element: Any) -> str:
+        """Renders a GitHub Flavored Markdown table as a reStructuredText grid table.
+
+        Args:
+            element (Any): The GFM table element.
+
+        Returns:
+            str: The rendered grid table as a string.
+        """
+        if not element.children:
+            return ""
+
+        header_row = element.children[0]
+        body_rows = element.children[1:]
+
+        header_values = [self.render_children(cell).strip() for cell in header_row.children]
+        row_values = []
+
+        for row in body_rows:
+            row_values.append([self.render_children(cell).strip() for cell in row.children])
+
+        return self._rst_create_grid_table(header_values, row_values)
+
+    def render_table_row(self, element: Any) -> str:
+        """Renders a GitHub Flavored Markdown table row.
+
+        Args:
+            element (Any): The table row element.
+
+        Returns:
+            str: The rendered row as a string.
+        """
+        return " | ".join(self.render_children(cell).strip() for cell in element.children)
+
+    def render_table_cell(self, element: Any) -> str:
+        """Renders a GitHub Flavored Markdown table cell.
+
+        Args:
+            element (Any): The table cell element.
+
+        Returns:
+            str: The rendered table cell as a string.
+        """
+        return self.render_children(element)
+
+    def render_strikethrough(self, element: Any) -> str:
+        """Renders a GitHub Flavored Markdown strikethrough element.
+
+        Args:
+            element (Any): The strikethrough element.
+
+        Returns:
+            str: The rendered strikethrough text.
+        """
+        return f"~~{self.render_children(element)}~~"
+
+    def render_url(self, element: Any) -> str:
+        """Renders a GitHub Flavored Markdown URL element.
+
+        Args:
+            element (Any): The URL element.
+
+        Returns:
+            str: The rendered URL as an RST link.
+        """
+        return self.render_link(cast("inline.Link", element))
+
+    @staticmethod
+    def _rst_table_append_border(char: str, max_widths: list[int]) -> str:
+        """
+        Appends a table border line for the grid table.
+
+        Args:
+            char (str): The character to use for the border line.
+            max_widths (list[int]): The maximum widths of the table columns.
+
+        Returns:
+            str: The rendered border line as a string.
+        """
+        return "+" + "+".join(char * (width + 2) for width in max_widths) + "+\n"
+
+    @staticmethod
+    def _rst_table_append_row(values: list[str], max_widths: list[int]) -> str:
+        """
+        Appends a table row for the grid table.
+
+        Args:
+            values (list[str]): The values for the row.
+            max_widths (list[int]): The maximum widths of the table columns.
+
+        Returns:
+            str: The rendered row as a string.
+        """
+        padded = [f" {value.ljust(max_widths[index])} " for index, value in enumerate(values)]
+
+        return "|" + "|".join(padded) + "|\n"
+
+    @staticmethod
+    def _rst_create_grid_table(headers: list[str], rows: list[list[str]]) -> str:
+        """Create a reStructuredText grid table.
+
+        Args:
+            headers (list[str]): Header row values.
+            rows (list[list[str]]): Body row values.
+
+        Returns:
+            str: The rendered grid table including trailing newline.
+        """
+        if len(headers) == 0:
+            return ""
+
+        max_widths = [len(value) for value in headers]
+
+        for row in rows:
+            for index, value in enumerate(row):
+                max_widths[index] = max(max_widths[index], len(value))
+
+        table = ""
+        table += Gfm2RstRenderer._rst_table_append_border("-", max_widths)
+        table += Gfm2RstRenderer._rst_table_append_row(headers, max_widths)
+        table += Gfm2RstRenderer._rst_table_append_border("=", max_widths)
+
+        for row in rows:
+            table += Gfm2RstRenderer._rst_table_append_row(row, max_widths)
+            table += Gfm2RstRenderer._rst_table_append_border("-", max_widths)
+
+        table += "\n"
+
+        return table
+
+# Functions ********************************************************************
+
+# Main *************************************************************************

--- a/src/pyTRLCConverter/marko/md2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/md2docx_renderer.py
@@ -1,4 +1,5 @@
 """Docx Renderer for Marko.
+    It is used to convert CommonMark AST to docx format.
 
     Author: Andreas Merkle (andreas.merkle@newtec.de)
 """
@@ -55,7 +56,7 @@ class Singleton(type):
         return cls._instances[cls]
 
 # pylint: disable-next=too-many-public-methods, too-many-instance-attributes
-class DocxRenderer(Renderer, metaclass=Singleton):
+class Md2DocxRenderer(Renderer, metaclass=Singleton):
     # lobster-trace: SwRequirements.sw_req_docx_render_md
     """Renderer for docx output."""
 
@@ -63,7 +64,7 @@ class DocxRenderer(Renderer, metaclass=Singleton):
     block_item_container: Optional[BlockItemContainer] = None
 
     def __init__(self) -> None:
-        """Initialize docx renderer."""
+        """Initialize the renderer."""
         super().__init__()
         self._list_indent_level = 0
         self._is_italic = False
@@ -245,7 +246,7 @@ class DocxRenderer(Renderer, metaclass=Singleton):
         Args:
             element (block.LinkRefDef): The link reference definition element to render.
         """
-        # reStructuredText uses reference links differently than Markdown.
+        # docx uses reference links differently than Markdown.
         # It shall not be rendered in the document.
 
     def render_emphasis(self, element: inline.Emphasis) -> None:

--- a/src/pyTRLCConverter/marko/md2rst_renderer.py
+++ b/src/pyTRLCConverter/marko/md2rst_renderer.py
@@ -1,4 +1,5 @@
 """reStructuredText renderer for Marko.
+    It is used to convert CommonMark AST to reStructuredText format.
 
     Author: Andreas Merkle (andreas.merkle@newtec.de)
 """
@@ -33,13 +34,16 @@ if TYPE_CHECKING:
 # Classes **********************************************************************
 
 # pylint: disable-next=too-many-public-methods
-class RSTRenderer(Renderer):
+class Md2RstRenderer(Renderer):
     # lobster-trace: SwRequirements.sw_req_rst_render_md
-    """Renderer for reStructuredText output."""
+    """
+    Renderer for reStructuredText output.
+    It is used to convert CommonMark Markdown to reStructuredText format.
+    """
 
     def __init__(self) -> None:
         """
-        Initializes the RSTRenderer.
+        Initializes the renderer.
         """
         super().__init__()
         self._list_indent_level = 0
@@ -305,6 +309,17 @@ class RSTRenderer(Renderer):
 
         Returns:
             str: The rendered auto link as a string.
+        """
+        return self.render_link(cast("inline.Link", element))
+
+    def render_url(self, element: Any) -> str:
+        """Renders a GitHub Flavored Markdown URL element.
+
+        Args:
+            element (Any): The URL element.
+
+        Returns:
+            str: The rendered URL as an RST link.
         """
         return self.render_link(cast("inline.Link", element))
 

--- a/src/pyTRLCConverter/render_config.py
+++ b/src/pyTRLCConverter/render_config.py
@@ -35,9 +35,10 @@ class RenderConfig():
     """Render configuration provider.
     """
 
-    FORMAT_SPECIFIER_PLAIN = "plain"
-    FORMAT_SPECIFIER_MD = "md"
-    FORMAT_SPECIFIER_RST = "rst"
+    FORMAT_SPECIFIER_PLAIN = "plain"    # Plain text format; no special formatting, e.g. for line breaks, lists, etc.
+    FORMAT_SPECIFIER_MD = "md"          # CommonMark Markdown format; https://spec.commonmark.org/0.31.2/
+    FORMAT_SPECIFIER_RST = "rst"        # ReStructuredText format; https://docutils.sourceforge.io/rst.html
+    FORMAT_SPECIFIER_GFM = "gfm"        # GitHub Flavored Markdown format; https://github.github.com/gfm/
 
     def __init__(self):
         """Constructs the render configuration provider.
@@ -194,6 +195,19 @@ class RenderConfig():
            bool: True if the given TRLC attribute has reStructuredText format, otherwise False.
         """
         return self.get_format_specifier(trlc_package, trlc_type, trlc_type_attribute) == self.FORMAT_SPECIFIER_RST
+
+    def is_format_gfm(self, trlc_package: str, trlc_type: str, trlc_type_attribute: str) -> bool:
+        """Checks if the given TRLC package, type and attribute should be rendered in GitHub Flavored Markdown format.
+
+        Args:
+            trlc_package (str): The TRLC package.
+            trlc_type (str): The TRLC type.
+            trlc_type_attribute (str): The TRLC type attribute.
+        
+        Returns:
+           bool: True if the given TRLC attribute has GitHub Flavored Markdown format, otherwise False.
+        """
+        return self.get_format_specifier(trlc_package, trlc_type, trlc_type_attribute) == self.FORMAT_SPECIFIER_GFM
 
 # Functions ********************************************************************
 

--- a/src/pyTRLCConverter/rst_converter.py
+++ b/src/pyTRLCConverter/rst_converter.py
@@ -28,7 +28,8 @@ from pyTRLCConverter.base_converter import BaseConverter
 from pyTRLCConverter.ret import Ret
 from pyTRLCConverter.trlc_helper import TrlcAstWalker
 from pyTRLCConverter.logger import log_verbose, log_error
-from pyTRLCConverter.marko.rst_renderer import RSTRenderer
+from pyTRLCConverter.marko.md2rst_renderer import Md2RstRenderer
+from pyTRLCConverter.marko.gfm2rst_renderer import Gfm2RstRenderer
 
 # Variables ********************************************************************
 
@@ -403,6 +404,7 @@ class RstConverter(BaseConverter):
     def _on_string_literal(self, string_literal: String_Literal) -> str:
         # lobster-trace: SwRequirements.sw_req_rst_string_format
         # lobster-trace: SwRequirements.sw_req_rst_render_md
+        # lobster-trace: SwRequirements.sw_req_rst_render_gfm
         """
         Process the given string literal value.
 
@@ -515,6 +517,7 @@ class RstConverter(BaseConverter):
     def _render(self, package_name: str, type_name: str, attribute_name: str, attribute_value: str) -> str:
         # lobster-trace: SwRequirements.sw_req_rst_string_format
         # lobster-trace: SwRequirements.sw_req_rst_render_md
+        # lobster-trace: SwRequirements.sw_req_rst_render_gfm
         """Render the attribute value depened on its format.
 
         Args:
@@ -531,10 +534,16 @@ class RstConverter(BaseConverter):
         # If the attribute value is not already in reStructuredText format, it will be escaped.
         if self._render_cfg.is_format_rst(package_name, type_name, attribute_name) is False:
 
-            # Is it Markdown format?
+            # Is it CommonMark Markdown format?
             if self._render_cfg.is_format_md(package_name, type_name, attribute_name) is True:
                 # Convert Markdown to reStructuredText.
-                markdown = Markdown(renderer=RSTRenderer)
+                markdown = Markdown(renderer=Md2RstRenderer)
+                result = markdown.convert(attribute_value)
+
+            # Is it GitHub Flavored Markdown format?
+            elif self._render_cfg.is_format_gfm(package_name, type_name, attribute_name) is True:
+                # Convert GitHub Flavored Markdown to reStructuredText.
+                markdown = Markdown(renderer=Gfm2RstRenderer, extensions=['gfm'])
                 result = markdown.convert(attribute_value)
 
             # Otherwise escape the text for reStructuredText.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,7 @@ def test_tc_cli_exclude(record_property, capsys, monkeypatch):
         "--source", "./tests/utils",
         "--exclude", "./tests/utils/single_req_with_link.trlc",
         "--exclude", "./tests/utils/single_req_description_md.trlc",
+        "--exclude", "./tests/utils/single_req_description_gfm.trlc",
         "--exclude", "./tests/utils/single_req_description_rst.trlc",
         "--exclude", "./tests/utils/multi_req_with_link.trlc",
         "--project", "./tests/utils/psc_simple",
@@ -152,6 +153,7 @@ def test_tc_cli_include(record_property, capsys, monkeypatch):
         "--source", "./tests/utils/req.rsl",
         "--source", "./tests/utils/single_req_with_link.trlc",  # Linking to req_2 in single_req_with_section.trlc
         "--exclude", "./tests/utils/single_req_description_md.trlc",
+        "--exclude", "./tests/utils/single_req_description_gfm.trlc",
         "--exclude", "./tests/utils/single_req_description_rst.trlc",
         "--exclude", "./tests/utils/multi_req_with_link.trlc",
         "--include", "./tests/utils",

--- a/tests/test_docx.py
+++ b/tests/test_docx.py
@@ -114,8 +114,8 @@ def test_tc_docx_multiple(record_property, capsys, monkeypatch, tmp_path):
     assert created_docx.tables[1].cell(2, 1).text == "Requirements.req_id_5"
 
     # Check that the hyperlink anchors were correctly set. Cells paragraph needs to hold a hyperlink with orrect anchor.
-    assert created_docx.tables[0].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_6"
-    assert created_docx.tables[1].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_5"
+    assert created_docx.tables[0].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_6" # pylint: disable=protected-access
+    assert created_docx.tables[1].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_5" # pylint: disable=protected-access
 
 def test_tc_docx_section(record_property, capsys, monkeypatch, tmp_path):
     # lobster-trace: SwTests.tc_docx_section
@@ -272,7 +272,7 @@ def test_tc_docx_render_md(record_property, capsys, monkeypatch, tmp_path):
     created_docx = docx.Document(docx=str(tmp_path / DocxConverter.OUTPUT_FILE_NAME_DEFAULT))
 
     # Check that the requirement is present.
-    assert created_docx.paragraphs[1].text == "req_id_4 (Requirement)"
+    assert created_docx.paragraphs[1].text == "req_id_md (Requirement)"
 
     # Check that the description was converted.
     assert created_docx.tables[0].cell(1, 0).text == "description"
@@ -304,4 +304,3 @@ def test_tc_docx_render_md(record_property, capsys, monkeypatch, tmp_path):
         r'',
         r'[Link to pyTRLCConverter](https://github.com/NewTec-GmbH/pyTRLCConverter)',
   ]
-    

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -27,6 +27,7 @@ from pyTRLCConverter.__main__ import main
 
 # Functions ********************************************************************
 
+# pylint: disable-next=too-many-statements
 def test_tc_ascii_conversion(record_property, capsys, monkeypatch):
     # lobster-trace: SwTests.tc_ascii_conversion
     """
@@ -44,6 +45,7 @@ def test_tc_ascii_conversion(record_property, capsys, monkeypatch):
         "pyTRLCConverter",
         "--source", "./tests/utils",
         "--exclude", "./tests/utils/single_req_description_md.trlc",
+        "--exclude", "./tests/utils/single_req_description_gfm.trlc",
         "--exclude", "./tests/utils/single_req_description_rst.trlc",
         "--exclude", "./tests/utils/multi_req_with_link.trlc",
         "dump"

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -495,6 +495,7 @@ def test_tc_markdown_single_doc_exclude(record_property, capsys, monkeypatch, tm
         "--exclude", "./tests/utils/single_req_no_section.trlc",
         "--exclude", "./tests/utils/single_req_with_section.trlc",
         "--exclude", "./tests/utils/single_req_description_md.trlc",
+        "--exclude", "./tests/utils/single_req_description_gfm.trlc",
         "--exclude", "./tests/utils/single_req_description_rst.trlc",
         "--exclude", "./tests/utils/multi_req_with_link.trlc",
         "--out", str(tmp_path),
@@ -720,7 +721,90 @@ Code block example
         line_index = 0
         line_index += _assert_heading(lines[line_index:], 1, "Specification")
         line_index += _assert_empty_line(lines[line_index:])
-        line_index += _assert_heading(lines[line_index:], 3, r"req\_id\_4")
+        line_index += _assert_heading(lines[line_index:], 3, r"req\_id\_md")
+        line_index += _assert_empty_line(lines[line_index:])
+        line_index += _assert_table(lines[line_index:],
+                                    [["Attribute Name", "Attribute Value"]],
+                                    [["description", attribute_value],
+                                     ["link", "N/A"],
+                                     ["index", "N/A"],
+                                     ["precision", "N/A"],
+                                     ["valid", "N/A"]])
+
+def test_tc_markdown_render_gfm(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_markdown_render_gfm
+    """
+    The software shall support rendering requirement attributes containing GitHub Flavored Markdown (GFM) syntax.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Path): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_markdown_render_gfm")
+
+    # Mock program arguments to specify an output folder.
+    output_file_name = "myReq.md"
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_gfm.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfgGfm.json",
+        "markdown",
+        "--single-document",
+        "--name", output_file_name
+    ])
+
+    # Expect the program to run without any exceptions.
+    main()
+
+    # Capture stdout and stderr.
+    captured = capsys.readouterr()
+    # Check that no errors were reported.
+    assert captured.err == ""
+
+    attribute_value = \
+'''# Heading 1
+
+## Heading 2
+
+- Bullet point 1
+- Bullet point 2
+    - Sub bullet point 1
+    - Sub bullet point 2
+
+1. Numbered point 1
+2. Numbered point 2
+    1. Sub numbered point 1
+    2. Sub numbered point 2
+
+**Bold text**, *italic text* and __underlined text__.
+
+```
+Code block example
+```
+
+--- Divider ---
+
+> Blockquote example
+
+[Link to pyTRLCConverter](https://github.com/NewTec-GmbH/pyTRLCConverter)
+
+| Col 0 | Col 1 |
+| ----- | ----- |
+| A     | B     |
+
+~~I am strikethrough.~~'''
+
+    # Verify
+    with open(os.path.join(tmp_path, output_file_name), "r", encoding='utf-8') as generated_md:
+        lines = generated_md.readlines()
+        line_index = 0
+        line_index += _assert_heading(lines[line_index:], 1, "Specification")
+        line_index += _assert_empty_line(lines[line_index:])
+        line_index += _assert_heading(lines[line_index:], 3, r"req\_id\_gfm")
         line_index += _assert_empty_line(lines[line_index:])
         line_index += _assert_table(lines[line_index:],
                                     [["Attribute Name", "Attribute Value"]],

--- a/tests/test_plantuml.py
+++ b/tests/test_plantuml.py
@@ -57,7 +57,8 @@ def plantuml_instance():
         return PlantUML()
 
 
-def test_make_server_url(record_property: any, plantuml_instance: PlantUML):
+# pylint: disable-next=redefined-outer-name
+def test_make_server_url(record_property, plantuml_instance: PlantUML):
     # lobster-trace: SwTests.tc_plantuml
     """
     Test the _make_server_url method of the PlantUML instance.
@@ -66,7 +67,7 @@ def test_make_server_url(record_property: any, plantuml_instance: PlantUML):
     of the diagram file and checks if the generated URL matches the expected URL.
     Args:
         record_property (Any): Used to inject the test case reference into the test results.
-        plantuml (PlantUML): An instance of the PlantUML class.
+        plantuml_instance (PlantUML): An instance of the PlantUML class.
     Asserts:
         The generated URL starts with the expected base URL.
         The generated URL matches the expected URL.

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -467,6 +467,7 @@ def test_tc_rst_single_doc_exclude(record_property, capsys, monkeypatch, tmp_pat
         "--exclude", "./tests/utils/single_req_no_section.trlc",
         "--exclude", "./tests/utils/single_req_with_section.trlc",
         "--exclude", "./tests/utils/single_req_description_md.trlc",
+        "--exclude", "./tests/utils/single_req_description_gfm.trlc",
         "--exclude", "./tests/utils/single_req_description_rst.trlc",
         "--exclude", "./tests/utils/multi_req_with_link.trlc",
         "--out", str(tmp_path),
@@ -641,12 +642,12 @@ def test_tc_rst_string_format(record_property, capsys, monkeypatch, tmp_path):
         assert "|                | - Bullet point 1    " in lines[18]
         assert "|                | - Bullet point 2    " in lines[19]
         assert "|                |   - Sub bullet point" in lines[20]
-                              
 
+# pylint: disable-next=too-many-statements
 def test_tc_rst_render_md(record_property, capsys, monkeypatch, tmp_path):
     # lobster-trace: SwTests.tc_rst_render_md
     """
-    The software shall support rendering requirement attributes containing Markdown syntax.
+    The software shall support rendering requirement attributes containing CommonMark Markdown syntax.
 
     Args:
         record_property (Any): Used to inject the test case reference into the test results.
@@ -685,9 +686,9 @@ def test_tc_rst_render_md(record_property, capsys, monkeypatch, tmp_path):
         assert lines[2] == "Specification\n"
         assert lines[3] == "=============\n"
         assert lines[4] == "\n"
-        assert lines[5] == ".. _myReq.rst-req\\_id\\_4:\n"
+        assert lines[5] == ".. _myReq.rst-req\\_id\\_md:\n"
         assert lines[6] == "\n"
-        assert lines[7] == ".. admonition:: req\\_id\\_4\n"
+        assert lines[7] == ".. admonition:: req\\_id\\_md\n"
         assert lines[8] == "\n"
         # pylint: disable=line-too-long
         assert lines[9] == "    +----------------+-----------------------------------------------------------------------------+\n"
@@ -754,3 +755,126 @@ def test_tc_rst_render_md(record_property, capsys, monkeypatch, tmp_path):
         assert lines[70] == "    +----------------+-----------------------------------------------------------------------------+\n"
         assert lines[71] == "    | valid          | N/A                                                                         |\n"
         assert lines[72] == "    +----------------+-----------------------------------------------------------------------------+\n"
+
+# pylint: disable-next=too-many-statements
+def test_tc_rst_render_gfm(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_rst_render_gfm
+    """
+    The software shall support rendering requirement attributes containing GitHub Flavored Markdown syntax.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Path): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_rst_render_gfm")
+
+    # Mock program arguments to specify an output folder.
+    output_file_name = "myReq.rst"
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_gfm.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfgGfm.json",
+        "rst",
+        "--single-document",
+        "--name", output_file_name
+    ])
+
+    # Expect the program to run without any exceptions.
+    main()
+
+    # Capture stdout and stderr.
+    captured = capsys.readouterr()
+    # Check that no errors were reported.
+    assert captured.err == ""
+
+    # Verify
+    with open(os.path.join(tmp_path, output_file_name), "r", encoding='utf-8') as generated_md:
+        lines = generated_md.readlines()
+        assert lines[0] == ".. _myReq.rst-specification:\n"
+        assert lines[1] == "\n"
+        assert lines[2] == "Specification\n"
+        assert lines[3] == "=============\n"
+        assert lines[4] == "\n"
+        assert lines[5] == ".. _myReq.rst-req\\_id\\_gfm:\n"
+        assert lines[6] == "\n"
+        assert lines[7] == ".. admonition:: req\\_id\\_gfm\n"
+        assert lines[8] == "\n"
+        # pylint: disable=line-too-long
+        assert lines[9] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[10] == "    | Attribute Name | Attribute Value                                                             |\n"
+        assert lines[11] == "    +================+=============================================================================+\n"
+        assert lines[12] == "    | description    | Heading 1                                                                   |\n"
+        assert lines[13] == "    |                | =========                                                                   |\n"
+        assert lines[14] == "    |                |                                                                             |\n"
+        assert lines[15] == "    |                |                                                                             |\n"
+        assert lines[16] == "    |                | Heading 2                                                                   |\n"
+        assert lines[17] == "    |                | ---------                                                                   |\n"
+        assert lines[18] == "    |                |                                                                             |\n"
+        assert lines[19] == "    |                |                                                                             |\n"
+        assert lines[20] == "    |                | - Bullet point 1                                                            |\n"
+        assert lines[21] == "    |                |                                                                             |\n"
+        assert lines[22] == "    |                |                                                                             |\n"
+        assert lines[23] == "    |                | - Bullet point 2                                                            |\n"
+        assert lines[24] == "    |                |                                                                             |\n"
+        assert lines[25] == "    |                |   - Sub bullet point 1                                                      |\n"
+        assert lines[26] == "    |                |                                                                             |\n"
+        assert lines[27] == "    |                |                                                                             |\n"
+        assert lines[28] == "    |                |   - Sub bullet point 2                                                      |\n"
+        assert lines[29] == "    |                |                                                                             |\n"
+        assert lines[30] == "    |                |                                                                             |\n"
+        assert lines[31] == "    |                |                                                                             |\n"
+        assert lines[32] == "    |                |                                                                             |\n"
+        assert lines[33] == "    |                | 1. Numbered point 1                                                         |\n"
+        assert lines[34] == "    |                |                                                                             |\n"
+        assert lines[35] == "    |                |                                                                             |\n"
+        assert lines[36] == "    |                | 2. Numbered point 2                                                         |\n"
+        assert lines[37] == "    |                |                                                                             |\n"
+        assert lines[38] == "    |                |   1. Sub numbered point 1                                                   |\n"
+        assert lines[39] == "    |                |                                                                             |\n"
+        assert lines[40] == "    |                |                                                                             |\n"
+        assert lines[41] == "    |                |   2. Sub numbered point 2                                                   |\n"
+        assert lines[42] == "    |                |                                                                             |\n"
+        assert lines[43] == "    |                |                                                                             |\n"
+        assert lines[44] == "    |                |                                                                             |\n"
+        assert lines[45] == "    |                |                                                                             |\n"
+        assert lines[46] == "    |                | **Bold text**, *italic text* and **underlined text**.                       |\n"
+        assert lines[47] == "    |                |                                                                             |\n"
+        assert lines[48] == "    |                |                                                                             |\n"
+        assert lines[49] == "    |                | .. code-block::                                                             |\n"
+        assert lines[50] == "    |                |                                                                             |\n"
+        assert lines[51] == "    |                |     Code block example                                                      |\n"
+        assert lines[52] == "    |                |                                                                             |\n"
+        assert lines[53] == "    |                |                                                                             |\n"
+        assert lines[54] == "    |                | --- Divider ---                                                             |\n"
+        assert lines[55] == "    |                |                                                                             |\n"
+        assert lines[56] == "    |                |                                                                             |\n"
+        assert lines[57] == "    |                |   Blockquote example                                                        |\n"
+        assert lines[58] == "    |                |                                                                             |\n"
+        assert lines[59] == "    |                |                                                                             |\n"
+        assert lines[60] == "    |                |                                                                             |\n"
+        assert lines[61] == "    |                | `Link to pyTRLCConverter <https://github.com/NewTec-GmbH/pyTRLCConverter>`_ |\n"
+        assert lines[62] == "    |                |                                                                             |\n"
+        assert lines[63] == "    |                |                                                                             |\n"
+        assert lines[64] == "    |                | +-------+-------+                                                           |\n"
+        assert lines[65] == "    |                | | Col 0 | Col 1 |                                                           |\n"
+        assert lines[66] == "    |                | +=======+=======+                                                           |\n"
+        assert lines[67] == "    |                | | A     | B     |                                                           |\n"
+        assert lines[68] == "    |                | +-------+-------+                                                           |\n"
+        assert lines[69] == "    |                |                                                                             |\n"
+        assert lines[70] == "    |                |                                                                             |\n"
+        assert lines[71] == "    |                | ~~I am strikethrough.~~                                                     |\n"
+        assert lines[72] == "    |                |                                                                             |\n"
+        assert lines[73] == "    |                |                                                                             |\n"
+        assert lines[74] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[75] == "    | link           | N/A                                                                         |\n"
+        assert lines[76] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[77] == "    | index          | N/A                                                                         |\n"
+        assert lines[78] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[79] == "    | precision      | N/A                                                                         |\n"
+        assert lines[80] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[81] == "    | valid          | N/A                                                                         |\n"
+        assert lines[82] == "    +----------------+-----------------------------------------------------------------------------+\n"

--- a/tests/utils/renderCfgGfm.json
+++ b/tests/utils/renderCfgGfm.json
@@ -1,0 +1,13 @@
+{
+    "renderCfg": [{
+        "package": "package",
+        "type": "typeRst",
+        "attribute": "description",
+        "format": "rst"
+    }, {
+        "package": ".*",
+        "type": ".*",
+        "attribute": "description",
+        "format": "gfm"
+    }]
+}

--- a/tests/utils/single_req_description_gfm.trlc
+++ b/tests/utils/single_req_description_gfm.trlc
@@ -1,6 +1,6 @@
 package Requirements
 
-Requirement req_id_md {
+Requirement req_id_gfm {
     description =
     '''
     # Heading 1
@@ -28,5 +28,11 @@ Requirement req_id_md {
     > Blockquote example
 
     [Link to pyTRLCConverter](https://github.com/NewTec-GmbH/pyTRLCConverter)
+
+    | Col 0 | Col 1 |
+    | ----- | ----- |
+    | A     | B     |
+
+    ~~I am strikethrough.~~
     '''
 }

--- a/tools/trlc2other/converter/renderCfg.json
+++ b/tools/trlc2other/converter/renderCfg.json
@@ -5,13 +5,13 @@
             "package": ".*",
             "type": "Info",
             "attribute": "description",
-            "format": "md"
+            "format": "gfm"
         },
         {
             "package": ".*",
             "type": "SwArchSpec",
             "attribute": "description",
-            "format": "md"
+            "format": "gfm"
         }
     ]   
 }

--- a/trlc/swe-arch/swe-arch.trlc
+++ b/trlc/swe-arch/swe-arch.trlc
@@ -250,6 +250,7 @@ section "SW Architecture" {
                 satisfies = [
                     SwRequirements.sw_req_translation,
                     SwRequirements.sw_req_rst_render_md,
+                    SwRequirements.sw_req_rst_render_gfm,
                     SwRequirements.sw_req_prj_spec_interface
                 ]
             }
@@ -311,6 +312,7 @@ section "SW Architecture" {
                     SwRequirements.sw_req_markdown_top_level_default,
                     SwRequirements.sw_req_markdown_top_level_custom,
                     SwRequirements.sw_req_markdown_render_md,
+                    SwRequirements.sw_req_markdown_render_gfm,
                     SwRequirements.sw_req_markdown_out_file_name_default,
                     SwRequirements.sw_req_destination_format
                 ]
@@ -352,6 +354,7 @@ section "SW Architecture" {
                     SwRequirements.sw_req_rst_sd_top_level_default,
                     SwRequirements.sw_req_rst_sd_top_level_custom,
                     SwRequirements.sw_req_rst_render_md,
+                    SwRequirements.sw_req_rst_render_gfm,
                     SwRequirements.sw_req_destination_format
                 ]
             }

--- a/trlc/swe-req/swe-req.trlc
+++ b/trlc/swe-req/swe-req.trlc
@@ -300,8 +300,14 @@ section "SW Requirements" {
             section "Markdown Render Configuration" {
 
                 SwReq sw_req_markdown_render_md {
-                    description = "The software shall render strings in Markdown format if specified in the render configuration."
-                    verification_criteria = "Verify by using strings in Markdown format, which needs no escaping."
+                    description = "The software shall render strings in [CommonMark's spec v0.31.2](https://spec.commonmark.org/0.31.2/) Markdown format if specified in the render configuration."
+                    verification_criteria = "Verify by using strings in Markdown format according to CommonMark's spec, which needs no escaping."
+                    valid_status = AbstractRequirements.VALID_STATUS.valid
+                }
+
+                SwReq sw_req_markdown_render_gfm {
+                    description = "The software shall render strings in [GitHub Flavored Markdown spec v0.29-gfm](https://github.github.com/gfm) Markdown format if specified in the render configuration."
+                    verification_criteria = "Verify by using strings in Markdown format according to GitHub Flavored Markdown spec, which needs no escaping."
                     valid_status = AbstractRequirements.VALID_STATUS.valid
                 }
             }
@@ -446,8 +452,14 @@ section "SW Requirements" {
             section "ReStructuredText Render Configuration" {
 
                 SwReq sw_req_rst_render_md {
-                    description = "The software shall convert strings in Markdown format to reStructuredText format if specified in the render configuration."
-                    verification_criteria = "Verify by using strings in Markdown format, that are converted."
+                    description = "The software shall convert strings in [CommonMark's spec v0.31.2](https://spec.commonmark.org/0.31.2/) Markdown format to reStructuredText format if specified in the render configuration."
+                    verification_criteria = "Verify by using strings in Markdown format according to CommonMark's spec, that are converted."
+                    valid_status = AbstractRequirements.VALID_STATUS.valid
+                }
+
+                SwReq sw_req_rst_render_gfm {
+                    description = "The software shall convert strings in [GitHub Flavored Markdown spec v0.29-gfm](https://github.github.com/gfm) Markdown format to reStructuredText format if specified in the render configuration."
+                    verification_criteria = "Verify by using strings in Markdown format according to GitHub Flavored Markdown spec, that are converted."
                     valid_status = AbstractRequirements.VALID_STATUS.valid
                 }
             }
@@ -498,8 +510,8 @@ section "SW Requirements" {
             section "Docx Render Configuration" {
 
                 SwReq sw_req_docx_render_md {
-                    description = "The software shall convert strings in Markdown format to docx format if specified in the render configuration."
-                    verification_criteria = "Verify by using strings in Markdown format, that are converted."
+                    description = "The software shall convert strings in [CommonMark's spec v0.31.2](https://spec.commonmark.org/0.31.2/) Markdown format to docx format if specified in the render configuration."
+                    verification_criteria = "Verify by using strings in Markdown format according to CommonMark's spec, that are converted."
                     valid_status = AbstractRequirements.VALID_STATUS.valid
                 }
             }

--- a/trlc/swe-test/swe-test.trlc
+++ b/trlc/swe-test/swe-test.trlc
@@ -186,9 +186,15 @@ section "SW-Test Cases" {
         }
 
         SwTestCase tc_markdown_render_md {
-            description = '''This test case checks whether Markdown content in requirement attributes is rendered correctly
+            description = '''This test case checks whether CommonMark Markdown content in requirement attributes is rendered correctly
              when the render configuration is set to "md".'''
             verifies = [SwRequirements.sw_req_markdown_render_md, SwRequirements.sw_req_markdown_string_format]
+        }
+
+        SwTestCase tc_markdown_render_gfm {
+            description = '''This test case checks whether GitHub Flavored Markdown content in requirement attributes is rendered correctly
+             when the render configuration is set to "gfm".'''
+            verifies = [SwRequirements.sw_req_markdown_render_gfm, SwRequirements.sw_req_markdown_string_format]
         }
     }
 
@@ -281,9 +287,15 @@ section "SW-Test Cases" {
         }
 
         SwTestCase tc_rst_render_md {
-            description = '''This test case checks whether Markdown content in requirement attributes is rendered correctly
+            description = '''This test case checks whether CommonMark Markdown content in requirement attributes is rendered correctly
              when the render configuration is set to "md".'''
             verifies = [SwRequirements.sw_req_rst_render_md]
+        }
+
+        SwTestCase tc_rst_render_gfm {
+            description = '''This test case checks whether GitHub Flavored Markdown content in requirement attributes is rendered correctly
+             when the render configuration is set to "gfm".'''
+            verifies = [SwRequirements.sw_req_rst_render_gfm]
         }
     }
 
@@ -315,7 +327,7 @@ section "SW-Test Cases" {
         }
 
         SwTestCase tc_docx_render_md {
-            description = "this test case checks whether the conversion from markdown strings to docx works correctly."
+            description = "this test case checks whether the conversion from CommonMark Markdown strings to docx works correctly."
             verifies = [SwRequirements.sw_req_docx_render_md]
         }
 


### PR DESCRIPTION
GitHub Flavored Markdown support added.
The major key is the support of tables.

#118 