### PR TITLE
Publish to pypi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,3 +120,51 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./tools/deployDoc/build/html/_static/version_selector_data.js
           destination_dir: ./versions
+
+  # Build the package distribution and upload it as a workflow artifact.
+  build-dist:
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    if: github.event_name == 'release'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build
+
+      - name: Build distribution
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
+          python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 5
+
+  # Publish the pre-built artifacts to PyPI on release.
+  publish-pypi:
+    runs-on: ubuntu-latest
+    needs: build-dist
+    if: github.event_name == 'release'
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,16 @@ jobs:
       - name: Install build tools
         run: python -m pip install --upgrade pip build
 
+      - name: Rewrite relative README links to absolute for PyPI
+        run: |
+          python -c "
+          import re, pathlib
+          tag = '${{ github.event.release.tag_name }}'
+          base = 'https://github.com/NewTec-GmbH/pyTRLCConverter/tree/' + tag + '/'
+          readme = pathlib.Path('README.md')
+          readme.write_text(re.sub(r'\]\(\.\/', '](' + base, readme.read_text()))
+          "
+
       - name: Build distribution
         run: |
           SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \

--- a/.gitignore
+++ b/.gitignore
@@ -7,21 +7,11 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-.Python
 build/
-develop-eggs/
 dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-var/
 wheels/
 share/python-wheels/
 *.egg-info/
-.installed.cfg
 *.egg
 MANIFEST
 version_selector_data.js

--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,6 @@ dmypy.json
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# Generated tool output directories
-doc/detailed-design/
-
 # Requirement conversion output files
 examples/plantuml/out/
 examples/simple_req/out/

--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ examples/simple_req_proj_spec/out/
 examples/simple_req_translation/out/
 tools/plantUML/plantuml.jar
 tools/*/out/
+tools/deployDoc/source/*.svg
 tests/out/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -124,6 +124,20 @@
                 "cwd": "${workspaceFolder}"
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Dump TRLC items to console",
+            "type": "shell",
+            "command": ".venv/Scripts/pyTRLCConverter",
+            "args": [
+                "--source", "tests/utils/req_mixed_types.rsl",
+                "--source", "tests/utils/multi_type_nested_sections.trlc",
+                "dump"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ python -m venv .venv
 
 Note:
 
-- For Windows CMD shell, use ```.venv\Scripts\activate.bat``` to activate the virtual environment.
-- For Linux/Macos, use ```source .venv/bin/activate``` to activate the virtual environment.
+- For Windows CMD shell, use `.venv\Scripts\activate.bat` to activate the virtual environment.
+- For Linux/Macos, use `source .venv/bin/activate` to activate the virtual environment.
 
 ### Tool Installation
 
@@ -100,17 +100,17 @@ pip install pyTRLCConverter
 
 ### Conversion to Markdown format
 
-The tool requires two kinds of TRLC input sources for the conversion. These are the requirements (\*.trlc) files and the model (\*.tls) files. These input files are specified using one or more --source  or -s options followed by a file name or directory path. If a path is given, all files with a .trlc or .tls extension are read by the tool.
+The tool requires two kinds of TRLC input sources for the conversion. These are the requirements (`*.trlc`) files and the model (`*.tls`) files. These input files are specified using one or more `--source` or `-s` options followed by a file name or directory path. If a path is given, all files with a `.trlc` or `.tls` extension are read by the tool.
 
 ```bash
 pyTRLCConverter --source trlc/model --source trlc/swe-req markdown
 ```
 
-It will create a Markdown file with the same name as the requirements file (\*.trlc) in the current directory, but with the Markdown extension (.md).
+It will create a Markdown file with the same name as the requirements file (`*.trlc`) in the current directory, but with the Markdown extension (`.md`).
 
-If the requirements are split into several files, a Markdown file will be created for each. To generate a single Markdown file the argument --single-document can be used, which will create an ```output.md``` file by default.
+If the requirements are split into several files, a Markdown file will be created for each. To generate a single Markdown file the argument `--single-document` can be used, which will create an `output.md` file by default.
 
-The converter supports additional arguments that are shown by adding the --help option after the markdown subcommand.
+The converter supports additional arguments that are shown by adding the `--help` option after the markdown subcommand.
 
 ```bash
 pyTRLCConverter markdown --help
@@ -130,17 +130,15 @@ More examples are shown in the [examples folder](./examples/).
 
 ### Conversion to docx format
 
-Similar to the Markdown conversion, minimal required are the requirements (\*.trlc) and the model (\*.tls). Both can be added by file name or just the path where they are located.
+Similar to the Markdown conversion, minimal required are the requirements (`*.trlc`) and the model (`*.tls`). Both can be added by file name or just the path where they are located.
 
 ```bash
 pyTRLCConverter --source trlc/model --source trlc/swe-req docx
 ```
 
-It will create a docx file with default name ```output.docx``` in the current directory.
+It will always create a single `output.docx` file in the current directory, regardless of how many TRLC source files are provided.
 
-If the requirements are split in several files, they will be all part of a single docx file.
-
-The converter supports additional arguments that are shown by adding the --help option after the docx subcommand.
+The converter supports additional arguments that are shown by adding the `--help` option after the docx subcommand.
 
 ```bash
 pyTRLCConverter docx --help
@@ -156,15 +154,15 @@ options:
 
 ### Conversion to reStructuredText format
 
-The tool requires two kinds of TRLC input sources for the conversion. These are the requirements (\*.trlc) files and the model (\*.tls) files. These input files are specified using one or more --source  or -s options followed by a file name or directory path. If a path is given, all files with a .trlc or .tls extension are read by the tool.
+The tool requires two kinds of TRLC input sources for the conversion. These are the requirements (`*.trlc`) files and the model (`*.tls`) files. These input files are specified using one or more `--source` or `-s` options followed by a file name or directory path. If a path is given, all files with a `.trlc` or `.tls` extension are read by the tool.
 
 ```bash
 pyTRLCConverter --source trlc/model --source trlc/swe-req rst
 ```
 
-If the requirements are split into several files (\*.trlc), a reStructuredText file will be created for each. To generate a single reStructuredText file the argument --single-document can be used, which will create an ```output.md``` file by default.
+If the requirements are split into several files (`*.trlc`), a reStructuredText file will be created for each. To generate a single reStructuredText file the argument `--single-document` can be used, which will create an `output.rst` file by default.
 
-The converter supports additional arguments that are shown by adding the --help option after the reStructuredText subcommand.
+The converter supports additional arguments that are shown by adding the `--help` option after the reStructuredText subcommand.
 
 ```bash
 pyTRLCConverter rst --help
@@ -186,15 +184,15 @@ More examples are shown in the [examples folder](./examples/).
 
 ### Conversion to ReqIF format
 
-The tool requires two kinds of TRLC input sources for the conversion. These are the requirements (*.trlc) files and the model (*.tls) files. These input files are specified using one or more --source or -s options followed by a file name or directory path. If a path is given, all files with a .trlc or .tls extension are read by the tool.
+The tool requires two kinds of TRLC input sources for the conversion. These are the requirements (`*.trlc`) files and the model (`*.tls`) files. These input files are specified using one or more `--source` or `-s` options followed by a file name or directory path. If a path is given, all files with a `.trlc` or `.tls` extension are read by the tool.
 
 ```bash
 pyTRLCConverter --source trlc/model --source trlc/swe-req reqif
 ```
 
-If the requirements are split into several files (*.trlc), a ReqIF file will be created for each. To generate a single ReqIF file the argument --single-document can be used, which will create an `output.reqif` file by default.
+If the requirements are split into several files (`*.trlc`), a ReqIF file will be created for each. To generate a single ReqIF file the argument `--single-document` can be used, which will create an `output.reqif` file by default.
 
-The converter supports additional arguments that are shown by adding the --help option after the ReqIF subcommand.
+The converter supports additional arguments that are shown by adding the `--help` option after the ReqIF subcommand.
 
 ```bash
 pyTRLCConverter reqif --help
@@ -256,7 +254,7 @@ pyTRLCConverter --source trlc/model --source trlc/swe-req dump
 
 The built-in converters display the requirements and their attributes in a table. The first column always contains the attribute name, and the second column contains the attribute value. Since the attribute names must comply with the TRLC standard, they are not always human-readable.
 
-Therefore a translation JSON file can be used to translate the attribute names. Use the ```--translation``` argument to specify the translation file.
+Therefore a translation JSON file can be used to translate the attribute names. Use the `--translation` argument to specify the translation file.
 
 Translation file example:
 
@@ -276,8 +274,8 @@ When requirements include lists or need bold/italic emphasis, TRLC currently sup
 
 Two Markdown specifications are supported:
 
-- "md": [CommonMark's spec v0.31.2](https://spec.commonmark.org/0.31.2/)
-- "gfm": [GitHub Flavored Markdown spec v0.29-gfm](https://github.github.com/gfm)
+- `"md"`: [CommonMark's spec v0.31.2](https://spec.commonmark.org/0.31.2/)
+- `"gfm"`: [GitHub Flavored Markdown spec v0.29-gfm](https://github.github.com/gfm)
 
 Supported by the formats:
 
@@ -306,21 +304,21 @@ Configuration example:
 
 The package, type and attribute supports regex which makes it easier to set the format for several types. Currently **only Markdown** is supported as format. Always the first match wins.
 
-Use the ```--renderCfg <RENDER-CFG-FILE>``` program argument to specify the configuration file.
+Use the `--renderCfg <RENDER-CFG-FILE>` program argument to specify the configuration file.
 
 ### Show tool version
 
-Show the version of the tool to see whether the required one is used.
+Show the installed tool version.
 
 ```bash
-pyTRLCConverter --help
+pyTRLCConverter --version
 ```
 
 ### PlantUML
 
 With the PlantUML extension the tool supports the automatic diagram generation out of a PlantUML file.
 
-Activate the support by setting the ```PLANTUML``` environment variable to either the path to a local `plantuml.jar` file or the URL of a PlantUML server.
+Activate the support by setting the `PLANTUML` environment variable to either the path to a local `plantuml.jar` file or the URL of a PlantUML server.
 
 | Environment Variable  | Description                                                                                                                                                     | Default |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ pyTRLCConverter is a command-line tool to convert [TRLC (Treat Requirements Like
 
 Currently out of the box supported formats:
 
-* Markdown
-* docx
-* reStructuredText
-* ReqIF
-* dump
+- Markdown
+- docx
+- reStructuredText
+- ReqIF
+- dump
 
 Find the requirements, test cases, coverage and etc. on the [github pages](https://newtec-gmbh.github.io/pyTRLCConverter/).
 
@@ -22,6 +22,7 @@ Find the requirements, test cases, coverage and etc. on the [github pages](https
   - [Clone this Project](#clone-this-project)
   - [Setup a virtual Python Environment](#setup-a-virtual-python-environment)
   - [Tool Installation](#tool-installation)
+  - [Install from PyPI](#install-from-pypi)
 - [Usage](#usage)
   - [Conversion to Markdown format](#conversion-to-markdown-format)
   - [Conversion to docx format](#conversion-to-docx-format)
@@ -34,6 +35,7 @@ Find the requirements, test cases, coverage and etc. on the [github pages](https
   - [PlantUML](#plantuml)
 - [Examples](#examples)
 - [Compile into an executable](#compile-into-an-executable)
+- [Publish to PyPI](#publish-to-pypi)
 - [SW Documentation](#sw-documentation)
 - [Tools](#tools)
 - [Used Libraries](#used-libraries)
@@ -84,6 +86,14 @@ The *users* of the tool install it as usual.
 
 ```bash
 pip install .
+```
+
+### Install from PyPI
+
+End users can install the latest stable release directly from PyPI without cloning the repository:
+
+```bash
+pip install pyTRLCConverter
 ```
 
 ## Usage
@@ -208,9 +218,9 @@ Conversion rules:
 
 **Types and spec-objects:**
 
-* Each distinct TRLC record type is mapped to one `SPEC-OBJECT-TYPE`. The type's attributes are reflected as `ATTRIBUTE-DEFINITION-*` entries on the type.
-* TRLC `section` headings are mapped to a dedicated `SPEC-OBJECT-TYPE` named `Section` and produce a container `SPEC-OBJECT` in the hierarchy.
-* Every TRLC record object produces one `SPEC-OBJECT` of the matching `SPEC-OBJECT-TYPE`.
+- Each distinct TRLC record type is mapped to one `SPEC-OBJECT-TYPE`. The type's attributes are reflected as `ATTRIBUTE-DEFINITION-*` entries on the type.
+- TRLC `section` headings are mapped to a dedicated `SPEC-OBJECT-TYPE` named `Section` and produce a container `SPEC-OBJECT` in the hierarchy.
+- Every TRLC record object produces one `SPEC-OBJECT` of the matching `SPEC-OBJECT-TYPE`.
 
 **Attribute mapping by field type:**
 
@@ -328,6 +338,28 @@ Just run the following command on the root of the folder:
 
 ```cmd
 pyinstaller --noconfirm --onefile --console --name "pyTRLCConverter" --add-data "./pyproject.toml;."  "./src/pyTRLCConverter/__main__.py"
+```
+
+## Publish to PyPI
+
+Releasing a new version to [PyPI](https://pypi.org/project/pyTRLCConverter/) is automated via the `deploy.yml` GitHub Actions workflow. Creating and publishing a GitHub release triggers the following steps automatically:
+
+1. Build the source distribution and wheel with `python -m build`.
+2. Upload the artifacts to PyPI using OIDC trusted publishing (no API token required).
+
+> **One-time setup:** Before the first automated release, configure a Trusted Publisher on PyPI (no API token needed). Go to the `pyTRLCConverter` project on PyPI → Manage → Publishing → Add a new publisher, and set Owner `NewTec-GmbH`, Repository `pyTRLCConverter`, Workflow `deploy.yml`.
+
+To trigger a release:
+
+1. Create and push a version tag, then publish a GitHub release for that tag.
+2. The `publish-pypi` job in `deploy.yml` runs automatically and uploads the distribution to PyPI.
+
+To test the build locally before releasing:
+
+```bash
+python -m pip install build twine
+python -m build
+twine check dist/*.whl dist/*.tar.gz
 ```
 
 ## SW Documentation

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ pyTRLCConverter --version
 
 ### PlantUML
 
-With the PlantUML extension the tool supports the automatic diagram generation out of a PlantUML file.
+With the PlantUML extension the tool supports automatic diagram generation from PlantUML files.
 
 Activate the support by setting the `PLANTUML` environment variable to either the path to a local `plantuml.jar` file or the URL of a PlantUML server.
 
@@ -363,9 +363,6 @@ twine check dist/*.whl dist/*.tar.gz
 ## SW Documentation
 
 More information on the deployment and architecture can be found in the [documentation](./doc/README.md)
-
-For Detailed Software Design run `$ /doc/detailed-design/make html` to generate the detailed design documentation that then can be found
-in the folder `/doc/detailed-design/_build/html/index.html`
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Used 3rd party libraries which are not part of the standard Python package:
 | [toml](https://github.com/uiri/toml)                         | Parsing [TOML](https://en.wikipedia.org/wiki/TOML)       | MIT        |
 | [trlc](https://github.com/bmw-software-engineering/trlc)     | Treat Requirements Like Code                             | GPL-3.0    |
 
-see also [requirements.txt](requirements.txt)
+See also [requirements.txt](requirements.txt).
 
 ## Issues, Ideas And Bugs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyTRLCConverter"
-version = "2.1.0"
+version = "2.2.0"
 description = "Supports the conversion from TRLC files to other formats."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pyTRLCConverter/item_walker.py
+++ b/src/pyTRLCConverter/item_walker.py
@@ -39,13 +39,7 @@ from pyTRLCConverter.ret import Ret
 # pylint: disable-next=too-few-public-methods
 class ItemWalker:
     # lobster-trace: SwRequirements.sw_req_process_trlc_symbols
-    """
-    A walker that traverses through the TRLC items in the given symbol table.
-
-    Attributes:
-        _converter (AbstractConverter): The converter used for processing items.
-        _exclude_files (list): List of file paths to exclude from processing.
-    """
+    """A walker that traverses through the TRLC items in the given symbol table."""
 
     def __init__(self, args: Any, converter: AbstractConverter) -> None:
         """

--- a/src/pyTRLCConverter/version.py
+++ b/src/pyTRLCConverter/version.py
@@ -63,7 +63,8 @@ def init_from_metadata():
         my_metadata.get('Version', '???'), \
         my_metadata.get('Author', '???'), \
         my_metadata.get('Author-email', '???'), \
-        next((u.split(", ", 1)[1] for u in (my_metadata.get_all('Project-URL') or []) if u.startswith("repository,")), '???'), \
+        next((u.split(", ", 1)[1] for u in (my_metadata.get_all('Project-URL') or [])
+              if u.startswith("repository,")), '???'), \
         my_metadata.get('License') or my_metadata.get('License-Expression', '???')
 
 def init_from_toml():

--- a/src/pyTRLCConverter/version.py
+++ b/src/pyTRLCConverter/version.py
@@ -63,8 +63,8 @@ def init_from_metadata():
         my_metadata.get('Version', '???'), \
         my_metadata.get('Author', '???'), \
         my_metadata.get('Author-email', '???'), \
-        my_metadata.get('Project-URL', 'repository, ???').replace("repository, ", ""), \
-        my_metadata.get('License', '???')
+        next((u.split(", ", 1)[1] for u in (my_metadata.get_all('Project-URL') or []) if u.startswith("repository,")), '???'), \
+        my_metadata.get('License') or my_metadata.get('License-Expression', '???')
 
 def init_from_toml():
     # lobster-trace: SwRequirements.sw_req_version

--- a/tools/deployDoc/README.md
+++ b/tools/deployDoc/README.md
@@ -1,9 +1,31 @@
 # deployDoc
 
+The static HTML documentation is built as part of the full documentation pipeline, which first
+generates RST files from TRLC sources, test reports, and the tracing report, then runs Sphinx.
+
+Run the pipeline from the `tools/` directory (one level above this folder):
+
 ## Windows
 
-To build the static HTML pages call ```make.bat html```, which generates them to ```./build/html```.
+```cmd
+cd tools
+make_html.bat
+```
 
 ## Linux
 
-To build the static HTML pages call ```make html```, which generates them to ```./build/html```.
+```bash
+cd tools
+./make_html.sh
+```
+
+An optional `online` argument enables online report generation (used in CI):
+
+```bash
+./make_html.sh online
+```
+
+The generated HTML is written to `tools/deployDoc/build/html/`.
+
+> **Note:** Do not run `make html` directly inside this folder — the required RST input files
+> will be missing and Sphinx will produce warnings and incomplete output.

--- a/tools/deployDoc/source/conf.py
+++ b/tools/deployDoc/source/conf.py
@@ -206,7 +206,7 @@ html_context = {
 
 # List of files to copy to the output directory.
 #
-# The source is relative to the sphinx directory.
+# The source is relative to the sphinx source directory.
 # The destination is relative to the output directory.
 files_to_copy = [
     {
@@ -220,6 +220,7 @@ files_to_copy = [
         'exclude': ['*.rst']
     }
 ]
+
 
 def setup(app: Any) -> None:
     """Setup sphinx.

--- a/tools/make_html.bat
+++ b/tools/make_html.bat
@@ -38,6 +38,10 @@ call testReport/make_rst
 rem Create tracing report from TRLC and source files.
 call traceReport/make %ONLINE_REPORT_OPTION%
 
+rem Copy SVG diagrams into the Sphinx source directory so relative image
+rem references in included RST files resolve correctly during the build.
+for %%f in (trlc2other\out\*.svg) do copy /Y "%%f" "deployDoc\source\" >nul
+
 rem Create HTML documentation.
 call deployDoc/make clean
 call deployDoc/make html

--- a/tools/make_html.sh
+++ b/tools/make_html.sh
@@ -42,5 +42,9 @@ fi
 # Create tracing report from TRLC and source files.
 (cd traceReport; ./make.sh $ONLINE_REPORT_OPTION)
 
+# Copy SVG diagrams into the Sphinx source directory so relative image
+# references in included RST files resolve correctly during the build.
+cp trlc2other/out/*.svg deployDoc/source/
+
 #Create HTML documentation.
 (cd plantUML; . ./get_plantuml.sh; cd ..;cd deployDoc; make clean; make html)


### PR DESCRIPTION
Closes #53 

Keep in mind that before the next release the owner of https://pypi.org/project/pyTRLCConverter/ (probably @BlueAndi) needs to set this up:

> **One-time setup:** Before the first automated release, configure a Trusted Publisher on PyPI (no API token needed). Go to the `pyTRLCConverter` project on PyPI → Manage → Publishing → Add a new publisher, and set Owner `NewTec-GmbH`, Repository `pyTRLCConverter`, Workflow `deploy.yml`.

See README.md.