### PR TITLE
Preserve PLANTUML env var if already set

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
     env:
       DOCS_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name == 'main' && 'latest' || github.ref_name == 'develop' && 'unstable' || github.ref_name }}
       DOCS_VERSIONS: unstable
+      PLANTUML: ${{ vars.PLANTUML_SERVER_URL }}
+      PLANTUML_VERIFY_SSL: "false"
 
     # Steps represent a sequence of tasks that will be executed as part of the job.
     steps:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     "python.testing.pytestEnabled": true,
     "autopep8.args": [
         "--max-line-length=120\""
+    ],
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "develop"
     ]
 }

--- a/tools/plantUML/get_plantuml.bat
+++ b/tools/plantUML/get_plantuml.bat
@@ -16,10 +16,12 @@ rem
 rem You should have received a copy of the GNU General Public License along with pyTRLCConverter.
 rem If not, see <https://www.gnu.org/licenses/>.
 
-set LOCAL_DIR=%~dp0
-set PLANTUML=%LOCAL_DIR%plantuml.jar
+if "%PLANTUML%" == "" (
+    set LOCAL_DIR=%~dp0
+    set PLANTUML=%LOCAL_DIR%plantuml.jar
 
-if not exist "%PLANTUML%" (
-    echo Download PlantUML java program...
-    powershell -Command "Invoke-WebRequest https://github.com/plantuml/plantuml/releases/download/v1.2026.1/plantuml-1.2026.1.jar -OutFile %PLANTUML%"
+    if not exist "%PLANTUML%" (
+        echo Download PlantUML java program...
+        powershell -Command "Invoke-WebRequest https://github.com/plantuml/plantuml/releases/download/v1.2026.1/plantuml-1.2026.1.jar -OutFile %PLANTUML%"
+    )
 )

--- a/tools/plantUML/get_plantuml.sh
+++ b/tools/plantUML/get_plantuml.sh
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU General Public License along with pyTRLCConverter.
 # If not, see <https://www.gnu.org/licenses/>.
 
-DIR=$(dirname `realpath "$_"`)
-PLANTUML="$DIR/plantuml.jar"
-export PLANTUML
+if [ -z "$PLANTUML" ]; then
+    DIR=$(dirname "$(realpath "$_")")
+    export PLANTUML="$DIR/plantuml.jar"
 
-if [ ! -f "$PLANTUML" ]; then
-    echo "Download PlantUML java program..."
-    curl -L -o "$PLANTUML" https://github.com/plantuml/plantuml/releases/download/v1.2026.1/plantuml-1.2026.1.jar
+    if [ ! -f "$PLANTUML" ]; then
+        echo "Download PlantUML java program..."
+        curl -L -o "$PLANTUML" https://github.com/plantuml/plantuml/releases/download/v1.2026.1/plantuml-1.2026.1.jar
+    fi
 fi


### PR DESCRIPTION
Skip defaulting to the local jar path when PLANTUML is already set, allowing a server URL (or any pre-configured value) to be passed through without being overwritten. Using an internal PlantUML server reduces make_html runtime from ~75s to ~50s.

Someone with sufficient project access rights (not me) can now in the GitHub repository go to **Settings → Secrets and variables → Actions → Variables → New repository variable** and add the following

| Name | Value |
|---|---|
| `PLANTUML_SERVER_URL` | `https://plantuml.devops.newtec.zz/` |
