### PR TITLE
Render inline PlantUML fenced code blocks as images

### DIFF
--- a/.claude/skills/conventional-commit/SKILL.md
+++ b/.claude/skills/conventional-commit/SKILL.md
@@ -49,7 +49,7 @@ git diff --cached --name-status
 git diff --cached --stat
 ```
 
-…and read the full diff in chunks rather than guessing. The commit message must reflect what actually changed.
+…and read the full diff in chunks rather than guessing. The commit message must reflect what actually changed. Do not take into consideration any unstaged changes for that. Treat unstaged changes as if they do not exist yet. This is needed to create compose the commit message from an atomic perspective.
 
 ### 3. Check recent history for style conventions
 

--- a/.claude/skills/conventional-commit/SKILL.md
+++ b/.claude/skills/conventional-commit/SKILL.md
@@ -49,7 +49,7 @@ git diff --cached --name-status
 git diff --cached --stat
 ```
 
-…and read the full diff in chunks rather than guessing. The commit message must reflect what actually changed. Do not take into consideration any unstaged changes for that. Treat unstaged changes as if they do not exist yet. This is needed to create compose the commit message from an atomic perspective.
+…and read the full diff in chunks rather than guessing. The commit message must reflect what actually changed.
 
 ### 3. Check recent history for style conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ pytest tests/test_reqif.py
 pytest tests/test_reqif.py::test_function_name
 
 # Lint (must be clean — no warnings or errors tolerated)
-pylint --rcfile=.pylintrc src/pyTRLCConverter/
+pylint --rcfile=.pylintrc src/pyTRLCConverter/ tests/
 
 # Run the tool directly
 pyTRLCConverter --source <trlc-dir> <subcommand>

--- a/README.md
+++ b/README.md
@@ -105,15 +105,18 @@ The converter supports additional arguments that are shown by adding the --help 
 ```bash
 pyTRLCConverter markdown --help
 
-usage: pyTRLCConverter markdown [-h] [-n NAME] [-sd] [-tl TOP_LEVEL]
+usage: pyTRLCConverter markdown [-h] [-e EMPTY] [-n NAME] [-sd] [-tl TOP_LEVEL] [--render-plantuml]
 
 options:
   -h, --help            show this help message and exit
+  -e EMPTY, --empty EMPTY
+                        Every attribute value which is empty will output the string (default = N/A).
   -n NAME, --name NAME  Name of the generated output file inside the output folder (default = output.md) in case a single document is generated.
   -sd, --single-document
                         Generate a single document instead of multiple files. The default is to generate multiple files.
   -tl TOP_LEVEL, --top-level TOP_LEVEL
-                        Name of the top level heading, required in single document mode. (default = Specification)
+                        Name of the top level heading, required in single document mode (default = Specification).
+  --render-plantuml     Render plantuml fenced code blocks as SVG image references. Without this option plantuml blocks are passed through unchanged.
 ```
 
 More examples are shown in the [examples folder](./examples/).
@@ -189,17 +192,18 @@ The converter supports additional arguments that are shown by adding the --help 
 ```bash
 pyTRLCConverter reqif --help
 
-usage: pyTRLCConverter reqif [-h] [-e EMPTY] [-n NAME] [-sd] [-tl TOP_LEVEL]
+usage: pyTRLCConverter reqif [-h] [-e EMPTY] [-n NAME] [-sd] [-tl TOP_LEVEL] [--reqifz]
 
 options:
   -h, --help            show this help message and exit
   -e EMPTY, --empty EMPTY
-                        Every attribute value which is empty will output the string (default = N/A).
+                        Every attribute value which is empty will output the string (default = ).
   -n NAME, --name NAME  Name of the generated output file inside the output folder (default = output.reqif) in case a single document is generated.
   -sd, --single-document
                         Generate a single document instead of multiple files. The default is to generate multiple files.
   -tl TOP_LEVEL, --top-level TOP_LEVEL
-                        Name of the top level section, required in single document mode (default = Specification).
+                        Name of the top level heading, required in single document mode (default = Specification).
+  --reqifz              Archive the ReqIF output as a ZIP file with the .reqifz extension. The default is to write plain .reqif files.
 ```
 
 Markdown-formatted requirement attributes configured via `--renderCfg` are automatically converted to ReqIF-compatible XHTML content.
@@ -271,15 +275,17 @@ Two Markdown specifications are supported:
 
 Supported by the formats:
 
-| Format           | CommonMark               | GitHub Flavored          | XHTML |
-| ---------------- | ------------------------ | ------------------------ | ----- |
-| docx             | X                        | X                        | -     |
-| dump             | Output as string literal | Output as string literal | -     |
-| markdown         | X                        | X                        | -     |
-| reStructuredText | X                        | X                        | -     |
-| reqif            | X                        | X                        | X     |
+| Format           | CommonMark               | GitHub Flavored          | XHTML | Inline PlantUML            |
+| ---------------- | ------------------------ | ------------------------ | ----- | -------------------------- |
+| docx             | X                        | X                        | -     | Embedded PNG               |
+| dump             | Output as string literal | Output as string literal | -     | -                          |
+| markdown         | X                        | X                        | -     | SVG (opt-in, see below)    |
+| reStructuredText | X                        | X                        | -     | SVG via `.. image::`       |
+| reqif            | X                        | X                        | X     | SVG via `<object>` element |
 
 The `reqif` format additionally supports `"xhtml"` as a format specifier in the render configuration. When set, the attribute value is treated as already-valid XHTML and is embedded in the ReqIF output without any conversion. This allows requirement authors to write raw XHTML markup directly in their TRLC string attributes.
+
+For the `markdown` format, inline PlantUML rendering is opt-in: pass `--render-plantuml` to the `markdown` subcommand to replace ```` ```plantuml```` blocks with SVG image references. Without this flag, PlantUML blocks are passed through unchanged — useful when the Markdown is consumed by a renderer that supports PlantUML natively (e.g. GitLab, some Sphinx extensions).
 
 Configuration example:
 
@@ -294,7 +300,7 @@ Configuration example:
 }
 ```
 
-The package, type and attribute supports regex which makes it easier to set the format for several types. Currently **only Markdown** is supported as format. Always the first match wins.
+The package, type and attribute fields support regex, which makes it easier to set the format for several types. Always the first match wins.
 
 Use the ```--renderCfg <RENDER-CFG-FILE>``` program argument to specify the configuration file.
 
@@ -319,7 +325,7 @@ Activate the support by setting the ```PLANTUML``` environment variable to eithe
 
 ## Examples
 
-Check out the all the [Examples](./examples).
+Check out the all the [Examples](./examples/README.md).
 
 ## Compile into an executable
 

--- a/doc/architecture/components/comp_docx_converter.puml
+++ b/doc/architecture/components/comp_docx_converter.puml
@@ -37,14 +37,20 @@ package "Dependencies" {
         + render(ast: Any) : str
     }
 
-    class Gfm2DocxRenderer {
-        + render(ast: Any) : str
+    class Gfm2DocxRenderer extends Md2DocxRenderer {
     }
 
     class marko <<(M ,lightblue) module>> {
     }
     note bottom of marko
         Markdown Parser
+    end note
+
+    class PlantUML {
+    }
+    note bottom of PlantUML
+        Renders inline ```plantuml```
+        fenced code blocks to PNG.
     end note
 }
 
@@ -53,5 +59,6 @@ DocxConverter ..> docx
 DocxConverter ..> Md2DocxRenderer
 DocxConverter ..> Gfm2DocxRenderer
 DocxConverter ..> marko
+Md2DocxRenderer ..> PlantUML
 
 @enduml

--- a/doc/architecture/components/comp_markdown_converter.puml
+++ b/doc/architecture/components/comp_markdown_converter.puml
@@ -11,6 +11,7 @@ class MarkdownConverter extends BaseConverter {
     +leave_file(file_name: str) : Ret
     +convert_section(section: str, level: int) : Ret
     +convert_record_object_generic(record: Record_Object, level: int, translation: Optional[dict]) : Ret
+    +finish() : Ret
 }
 
 
@@ -30,9 +31,18 @@ package "Dependencies" {
 
     class TrlcAstWalker {
     }
+
+    class PlantUML {
+    }
+    note bottom of PlantUML
+        Renders inline ```plantuml```
+        fenced code blocks to SVG
+        when --render-plantuml is set.
+    end note
 }
 
 MarkdownConverter ..> "trlc"
 MarkdownConverter ..> TrlcAstWalker
+MarkdownConverter ..> PlantUML
 
 @enduml

--- a/doc/architecture/components/comp_plantuml.puml
+++ b/doc/architecture/components/comp_plantuml.puml
@@ -2,8 +2,9 @@
 
 class PlantUML {
     +__init__() : None
-    +set_server_url(url: str) : None
-    +generate_image(source: str, output_path: str) : None
+    +is_plantuml_file(diagram_path: str) : bool
+    +generate(diagram_type: str, diagram_path: str, dst_path: str) : None
+    +generate_to_bytes(diagram_type: str, diagram_source: str) : bytes
 }
 
 

--- a/doc/architecture/components/comp_reqif_converter.puml
+++ b/doc/architecture/components/comp_reqif_converter.puml
@@ -11,6 +11,7 @@ class ReqifConverter extends BaseConverter {
     +leave_file(file_name: str) : Ret
     +convert_section(section: str, level: int) : Ret
     +convert_record_object_generic(record: Record_Object, level: int, translation: Optional[dict]) : Ret
+    +finish() : Ret
 }
 
 
@@ -31,8 +32,25 @@ package "Dependencies" {
     class TrlcAstWalker {
     }
 
+    class Md2ReqifRenderer {
+        + render(ast: Any) : str
+    }
+
+    class Gfm2ReqifRenderer extends Md2ReqifRenderer {
+    }
+
     class "marko" <<(M ,lightblue) module>> {
     }
+    note bottom of "marko"
+        Markdown Parser
+    end note
+
+    class PlantUML {
+    }
+    note bottom of PlantUML
+        Renders inline ```plantuml```
+        fenced code blocks to SVG.
+    end note
 
     class "reqif" <<(M ,lightblue) module>> {
     }
@@ -40,7 +58,10 @@ package "Dependencies" {
 
 ReqifConverter ..> "trlc"
 ReqifConverter ..> TrlcAstWalker
+ReqifConverter ..> Md2ReqifRenderer
+ReqifConverter ..> Gfm2ReqifRenderer
 ReqifConverter ..> "marko"
 ReqifConverter ..> "reqif"
+Md2ReqifRenderer ..> PlantUML
 
 @enduml

--- a/doc/architecture/components/comp_rst_converter.puml
+++ b/doc/architecture/components/comp_rst_converter.puml
@@ -37,14 +37,20 @@ package "Dependencies" {
         + render(ast: Any) : str
     }
 
-    class Gfm2RstRenderer {
-        + render(ast: Any) : str
+    class Gfm2RstRenderer extends Md2RstRenderer {
     }
 
     class marko <<(M ,lightblue) module>> {
     }
     note bottom of marko
         Markdown Parser
+    end note
+
+    class PlantUML {
+    }
+    note bottom of PlantUML
+        Renders inline ```plantuml```
+        fenced code blocks to SVG.
     end note
 }
 
@@ -54,5 +60,6 @@ RstConverter ..> TrlcAstWalker
 RstConverter ..> Md2RstRenderer
 RstConverter ..> Gfm2RstRenderer
 RstConverter ..> marko
+Md2RstRenderer ..> PlantUML
 
 @enduml

--- a/doc/architecture/components/comp_rst_converter.puml
+++ b/doc/architecture/components/comp_rst_converter.puml
@@ -12,6 +12,7 @@ class RstConverter extends BaseConverter {
     +leave_file(file_name: str) : Ret
     +convert_section(section: str, level: int) : Ret
     +convert_record_object_generic(record: Record_Object, level: int, translation: Optional[dict]) : Ret
+    +finish() : Ret
 }
 
 ' Define external dependencies

--- a/src/pyTRLCConverter/markdown_converter.py
+++ b/src/pyTRLCConverter/markdown_converter.py
@@ -20,10 +20,15 @@
 # If not, see <https://www.gnu.org/licenses/>.
 
 # Imports **********************************************************************
+import hashlib
 import os
+import re
+import shutil
+import tempfile
 from typing import List, Optional, Any
 from trlc.ast import Implicit_Null, Record_Object, Record_Reference, String_Literal, Expression
 from pyTRLCConverter.base_converter import BaseConverter
+from pyTRLCConverter.plantuml import PlantUML
 from pyTRLCConverter.ret import Ret
 from pyTRLCConverter.trlc_helper import TrlcAstWalker
 from pyTRLCConverter.logger import log_verbose, log_error
@@ -82,6 +87,9 @@ class MarkdownConverter(BaseConverter):
         # This will hold the information about the current package, type and attribute being processed.
         self._ast_meta_data = None
 
+        self._plantuml_tmp_dir: Optional[tempfile.TemporaryDirectory] = None
+        self._external_files: list = []
+
     @staticmethod
     def get_subcommand() -> str:
         # lobster-trace: SwRequirements.sw_req_markdown
@@ -112,6 +120,8 @@ class MarkdownConverter(BaseConverter):
         # lobster-trace: SwRequirements.sw_req_markdown_top_level_custom
         # lobster-trace: SwRequirements.sw_req_markdown_out_file_name_default
         # lobster-trace: SwRequirements.sw_req_markdown_out_file_name_custom
+        # lobster-trace: SwRequirements.sw_req_markdown_render_plantuml
+        # lobster-trace: SwRequirements.sw_req_cli_render_plantuml
         """
         Register converter specific argument parser.
 
@@ -162,6 +172,15 @@ class MarkdownConverter(BaseConverter):
                 f"(default = {MarkdownConverter.TOP_LEVEL_DEFAULT})."
         )
 
+        BaseConverter._parser.add_argument(
+            "--render-plantuml",
+            action="store_true",
+            required=False,
+            default=False,
+            help="Render plantuml fenced code blocks as SVG image references. "
+                 "Without this option plantuml blocks are passed through unchanged."
+        )
+
     def begin(self) -> Ret:
         # lobster-trace: SwRequirements.sw_req_markdown_single_doc_mode
         # lobster-trace: SwRequirements.sw_req_markdown_sd_top_level
@@ -188,6 +207,12 @@ class MarkdownConverter(BaseConverter):
             self._empty_attribute_value = self._args.empty
 
             log_verbose(f"Empty attribute value: {self._empty_attribute_value}")
+
+            if self._args.render_plantuml is True:
+                # pylint: disable-next=consider-using-with
+                self._plantuml_tmp_dir = tempfile.TemporaryDirectory(
+                    prefix="pyTRLCConverter_markdown_"
+                )
 
             # Single document mode?
             if self._args.single_document is True:
@@ -241,9 +266,12 @@ class MarkdownConverter(BaseConverter):
         # Multiple document mode?
         if self._args.single_document is False:
             assert self._fd is not None
+            out_dir = os.path.dirname(self._fd.name)
             self._fd.close()
             self._fd = None
             self._is_top_level_heading_req = True
+            self._copy_external_files(out_dir)
+            self._external_files = []
 
         return Ret.OK
 
@@ -307,8 +335,14 @@ class MarkdownConverter(BaseConverter):
         # Single document mode?
         if self._args.single_document is True:
             assert self._fd is not None
+            out_dir = os.path.dirname(self._fd.name)
             self._fd.close()
             self._fd = None
+            self._copy_external_files(out_dir)
+
+        if self._plantuml_tmp_dir is not None:
+            self._plantuml_tmp_dir.cleanup()
+            self._plantuml_tmp_dir = None
 
         return Ret.OK
 
@@ -538,7 +572,8 @@ class MarkdownConverter(BaseConverter):
         # lobster-trace: SwRequirements.sw_req_markdown_string_format
         # lobster-trace: SwRequirements.sw_req_markdown_render_md
         # lobster-trace: SwRequirements.sw_req_markdown_render_gfm
-        """Render the attribute value depened on its format.
+        # lobster-trace: SwRequirements.sw_req_markdown_render_plantuml
+        """Render the attribute value depending on its format.
 
         Args:
             package_name (str): The package name.
@@ -558,7 +593,66 @@ class MarkdownConverter(BaseConverter):
             result = self.markdown_escape(attribute_value)
             result = self.markdown_lf2soft_return(result)
 
+        if self._args.render_plantuml is True:
+            result = self._render_plantuml_blocks(result)
+
         return result
+
+    def _render_plantuml_blocks(self, text: str) -> str:
+        # lobster-trace: SwRequirements.sw_req_markdown_render_plantuml
+        # lobster-trace: SwRequirements.sw_req_plantuml
+        """Replace plantuml fenced code blocks with SVG image references.
+
+        Each ```plantuml ... ``` block is replaced by ``![](plantuml_<hash>.svg)``.
+        The SVG is written to the temporary image directory and registered in
+        ``_external_files`` for copying to the output folder. On failure an
+        inline ``[PlantUML error: ...]`` text is emitted instead.
+
+        Args:
+            text (str): Markdown text that may contain plantuml fenced blocks.
+
+        Returns:
+            str: Text with plantuml blocks replaced.
+        """
+        assert self._plantuml_tmp_dir is not None
+
+        def _replace(match: re.Match) -> str:
+            diagram_source = match.group(1)
+            try:
+                plantuml = PlantUML()
+                svg_bytes = plantuml.generate_to_bytes("svg", diagram_source)
+                digest = hashlib.sha1(diagram_source.encode("utf-8")).hexdigest()[:12]
+                local_name = f"plantuml_{digest}.svg"
+                svg_path = os.path.join(self._plantuml_tmp_dir.name, local_name)
+                with open(svg_path, "wb") as svg_file:
+                    svg_file.write(svg_bytes)
+                self._external_files.append((svg_path, local_name))
+                return f"![]({local_name})"
+            except (FileNotFoundError, OSError) as exc:
+                return f"[PlantUML error: {exc}]"
+
+        return re.sub(r"```plantuml\n(.*?)```", _replace, text, flags=re.DOTALL)
+
+    def _copy_external_files(self, dest_dir: str) -> None:
+        # lobster-trace: SwRequirements.sw_req_markdown_render_plantuml
+        """Copy all collected external files to the given destination directory.
+
+        Args:
+            dest_dir (str): Destination directory path.
+        """
+        copied_sources = set()
+
+        for source_path, local_name in self._external_files:
+            if source_path in copied_sources:
+                continue
+
+            dest_path = os.path.join(dest_dir, local_name)
+
+            try:
+                shutil.copy2(source_path, dest_path)
+                copied_sources.add(source_path)
+            except (OSError, IOError) as exc:
+                log_error(f"Failed to copy external file '{source_path}': {exc}", False)
 
     # pylint: disable-next=too-many-locals
     def _convert_record_object(self, record: Record_Object, level: int, translation: Optional[dict]) -> Ret:

--- a/src/pyTRLCConverter/marko/gfm2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/gfm2docx_renderer.py
@@ -44,6 +44,7 @@ class Gfm2DocxRenderer(Md2DocxRenderer, metaclass=Singleton):
         """Initialize the renderer."""
         self._checkbox_prefix: Optional[str] = None
         super().__init__()
+        self.reset()
 
     def reset(self) -> None:
         """Resets the renderer state before a new convert() call."""

--- a/src/pyTRLCConverter/marko/gfm2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/gfm2docx_renderer.py
@@ -42,8 +42,8 @@ class Gfm2DocxRenderer(Md2DocxRenderer, metaclass=Singleton):
 
     def __init__(self) -> None:
         """Initialize the renderer."""
-        super().__init__()
         self._checkbox_prefix: Optional[str] = None
+        super().__init__()
 
     def reset(self) -> None:
         """Resets the renderer state before a new convert() call."""

--- a/src/pyTRLCConverter/marko/gfm2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/gfm2docx_renderer.py
@@ -42,9 +42,8 @@ class Gfm2DocxRenderer(Md2DocxRenderer, metaclass=Singleton):
 
     def __init__(self) -> None:
         """Initialize the renderer."""
-        self._checkbox_prefix: Optional[str] = None
         super().__init__()
-        self.reset()
+        self._checkbox_prefix: Optional[str] = None
 
     def reset(self) -> None:
         """Resets the renderer state before a new convert() call."""

--- a/src/pyTRLCConverter/marko/gfm2reqif_renderer.py
+++ b/src/pyTRLCConverter/marko/gfm2reqif_renderer.py
@@ -1,0 +1,47 @@
+"""ReqIF Renderer for Marko.
+    It is used to convert GitHub Flavored Markdown AST to ReqIF-compatible XHTML.
+
+    Author: Stefan Vogel (stefan.vogel@newtec.de)
+"""
+
+# pyTRLCConverter - A tool to convert TRLC files to specific formats.
+# Copyright (c) 2024 - 2026 NewTec GmbH
+#
+# This file is part of pyTRLCConverter program.
+#
+# The pyTRLCConverter program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# The pyTRLCConverter program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with pyTRLCConverter.
+# If not, see <https://www.gnu.org/licenses/>.
+
+# Imports **********************************************************************
+
+from __future__ import annotations
+from pyTRLCConverter.marko.md2reqif_renderer import Md2ReqifRenderer
+
+# Variables ********************************************************************
+
+# Classes **********************************************************************
+
+
+class Gfm2ReqifRenderer(Md2ReqifRenderer):
+    # lobster-trace: SwRequirements.sw_req_reqif_render_gfm
+    # lobster-trace: SwRequirements.sw_req_reqif_render_plantuml
+    # lobster-trace: SwRequirements.sw_req_plantuml
+    """Renderer for ReqIF XHTML output from GitHub Flavored Markdown.
+
+    Inherits the inline PlantUML handling from :class:`Md2ReqifRenderer`.
+    The GFM extension is applied by the surrounding ``Markdown`` instance, so
+    this subclass only exists to provide a distinct renderer type for the GFM
+    code path.
+    """
+
+# Functions ********************************************************************
+
+# Main *************************************************************************

--- a/src/pyTRLCConverter/marko/gfm2rst_renderer.py
+++ b/src/pyTRLCConverter/marko/gfm2rst_renderer.py
@@ -36,9 +36,12 @@ if TYPE_CHECKING:
 # pylint: disable-next=too-many-public-methods
 class Gfm2RstRenderer(Md2RstRenderer):
     # lobster-trace: SwRequirements.sw_req_rst_render_gfm
-    """
-    Renderer for reStructuredText output.
-    It is used to convert GitHub Flavored Markdown to reStructuredText format.
+    # lobster-trace: SwRequirements.sw_req_rst_render_plantuml
+    # lobster-trace: SwRequirements.sw_req_plantuml
+    """Renderer for reStructuredText output.
+
+    Converts GitHub Flavored Markdown to reStructuredText format.
+    Inherits inline PlantUML handling from :class:`Md2RstRenderer`.
     """
 
     # Inherit all CommonMark rendering behavior from Md2RstRenderer and override only GFM additions.

--- a/src/pyTRLCConverter/marko/md2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/md2docx_renderer.py
@@ -69,6 +69,16 @@ class Md2DocxRenderer(Renderer, metaclass=Singleton):
     def __init__(self) -> None:
         """Initialize the renderer."""
         super().__init__()
+        self._list_indent_level = 0
+        self._is_italic = False
+        self._is_bold = False
+        self._is_underline = False
+        self._is_heading = False
+        self._heading_level = 0
+        self._is_list_item = False
+        self._list_style = []
+        self._is_quote = False
+        self._current_paragraph = None
         self.reset()
 
     def reset(self) -> None:

--- a/src/pyTRLCConverter/marko/md2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/md2docx_renderer.py
@@ -69,16 +69,6 @@ class Md2DocxRenderer(Renderer, metaclass=Singleton):
     def __init__(self) -> None:
         """Initialize the renderer."""
         super().__init__()
-        self._list_indent_level = 0
-        self._is_italic = False
-        self._is_bold = False
-        self._is_underline = False
-        self._is_heading = False
-        self._heading_level = 0
-        self._is_list_item = False
-        self._list_style = []
-        self._is_quote = False
-        self._current_paragraph = None
         self.reset()
 
     def reset(self) -> None:
@@ -89,24 +79,6 @@ class Md2DocxRenderer(Renderer, metaclass=Singleton):
         into the next call and cause spurious empty paragraphs in the output.
         """
         self.root_node = None
-        self._list_indent_level = 0
-        self._is_italic = False
-        self._is_bold = False
-        self._is_underline = False
-        self._is_heading = False
-        self._heading_level = 0
-        self._is_list_item = False
-        self._list_style = []
-        self._is_quote = False
-        self._current_paragraph = None
-
-    def reset(self) -> None:
-        """Resets the renderer state before a new convert() call.
-
-        The Singleton pattern means __init__ runs only once. Without an explicit reset,
-        stale state from a previous convert() call (e.g. _current_paragraph) would persist
-        into the next call and cause spurious empty paragraphs in the output.
-        """
         self._list_indent_level = 0
         self._is_italic = False
         self._is_bold = False

--- a/src/pyTRLCConverter/marko/md2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/md2docx_renderer.py
@@ -180,6 +180,9 @@ class Md2DocxRenderer(Renderer, metaclass=Singleton):
         self._is_quote = False
 
     def render_fenced_code(self, element: block.FencedCode) -> None:
+        # lobster-trace: SwRequirements.sw_req_docx_render_md
+        # lobster-trace: SwRequirements.sw_req_docx_render_plantuml
+        # lobster-trace: SwRequirements.sw_req_plantuml
         """
         Renders a fenced code block element.
 
@@ -202,6 +205,8 @@ class Md2DocxRenderer(Renderer, metaclass=Singleton):
             run.font.name = "Consolas"
 
     def _render_plantuml(self, diagram_source: str) -> None:
+        # lobster-trace: SwRequirements.sw_req_docx_render_plantuml
+        # lobster-trace: SwRequirements.sw_req_plantuml
         """Renders a PlantUML diagram as an embedded PNG in the docx document.
 
         Generates PNG bytes via the PlantUML tool and embeds the image directly.

--- a/src/pyTRLCConverter/marko/md2docx_renderer.py
+++ b/src/pyTRLCConverter/marko/md2docx_renderer.py
@@ -100,6 +100,24 @@ class Md2DocxRenderer(Renderer, metaclass=Singleton):
         self._is_quote = False
         self._current_paragraph = None
 
+    def reset(self) -> None:
+        """Resets the renderer state before a new convert() call.
+
+        The Singleton pattern means __init__ runs only once. Without an explicit reset,
+        stale state from a previous convert() call (e.g. _current_paragraph) would persist
+        into the next call and cause spurious empty paragraphs in the output.
+        """
+        self._list_indent_level = 0
+        self._is_italic = False
+        self._is_bold = False
+        self._is_underline = False
+        self._is_heading = False
+        self._heading_level = 0
+        self._is_list_item = False
+        self._list_style = []
+        self._is_quote = False
+        self._current_paragraph = None
+
     def render_children(self, element: Any) -> None:
         """
         Recursively renders child elements of a given element to

--- a/src/pyTRLCConverter/marko/md2reqif_renderer.py
+++ b/src/pyTRLCConverter/marko/md2reqif_renderer.py
@@ -1,0 +1,133 @@
+"""ReqIF Renderer for Marko.
+    It is used to convert CommonMark AST to ReqIF-compatible XHTML.
+
+    Author: Andreas Merkle (andreas.merkle@newtec.de)
+"""
+
+# pyTRLCConverter - A tool to convert TRLC files to specific formats.
+# Copyright (c) 2024 - 2026 NewTec GmbH
+#
+# This file is part of pyTRLCConverter program.
+#
+# The pyTRLCConverter program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# The pyTRLCConverter program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with pyTRLCConverter.
+# If not, see <https://www.gnu.org/licenses/>.
+
+# Imports **********************************************************************
+
+from __future__ import annotations
+import hashlib
+import html
+import os
+from typing import TYPE_CHECKING, Optional
+from marko.html_renderer import HTMLRenderer
+from pyTRLCConverter.plantuml import PlantUML
+
+if TYPE_CHECKING:
+    from marko import block
+
+# Variables ********************************************************************
+
+# Classes **********************************************************************
+
+
+class Md2ReqifRenderer(HTMLRenderer):
+    # lobster-trace: SwRequirements.sw_req_reqif_render_md
+    # lobster-trace: SwRequirements.sw_req_reqif_render_plantuml
+    # lobster-trace: SwRequirements.sw_req_plantuml
+    """Renderer for ReqIF XHTML output.
+
+    Extends marko's CommonMark HTML renderer so that fenced code blocks tagged
+    ``plantuml`` are rendered as embedded SVG images referenced via XHTML
+    ``<object>`` elements. Other fenced code blocks are rendered by the parent
+    class as ``<pre><code>`` blocks.
+    """
+
+    # Destination directory where generated SVG images are written. The
+    # converter is responsible for setting this before each ``convert()`` call
+    # and for ensuring the directory exists and survives until the external
+    # files have been copied to the final output location.
+    image_dir: Optional[str] = None
+
+    # List of ``(source_path, local_name)`` tuples collected during rendering.
+    # The converter merges these into its own ``_external_files`` list so the
+    # images are copied alongside the ReqIF document.
+    external_files: Optional[list] = None
+
+    def render_fenced_code(self, element: "block.FencedCode") -> str:
+        # lobster-trace: SwRequirements.sw_req_reqif_render_md
+        # lobster-trace: SwRequirements.sw_req_plantuml
+        """Render a fenced code block as ReqIF XHTML.
+
+        If the language tag is ``plantuml``, the diagram source is rendered as
+        an embedded SVG image referenced via an XHTML ``<object>`` element.
+        If PlantUML is not available, an error string is emitted instead.
+        For all other language tags the block is rendered by the parent class.
+
+        Args:
+            element (block.FencedCode): The fenced code block element to render.
+
+        Returns:
+            str: XHTML representation of the fenced code block.
+        """
+        if element.lang == "plantuml":
+            return self._render_plantuml(element.children[0].children)
+
+        return super().render_fenced_code(element)
+
+    def _render_plantuml(self, diagram_source: str) -> str:
+        # lobster-trace: SwRequirements.sw_req_reqif_render_md
+        # lobster-trace: SwRequirements.sw_req_plantuml
+        """Render a PlantUML diagram as an embedded SVG reference.
+
+        Generates SVG bytes via the PlantUML tool, writes them to a temporary
+        file under :attr:`image_dir`, registers the file in
+        :attr:`external_files` so the converter can copy it next to the ReqIF
+        document, and returns an XHTML ``<object>`` element referencing the
+        image by its local name.
+
+        On failure (PlantUML not available, server error, ...) an error
+        paragraph is emitted instead.
+
+        Args:
+            diagram_source (str): The PlantUML diagram source text.
+
+        Returns:
+            str: XHTML fragment referencing the generated image, or an error
+                paragraph if image generation failed.
+        """
+        assert Md2ReqifRenderer.image_dir is not None
+        assert Md2ReqifRenderer.external_files is not None
+
+        try:
+            plantuml = PlantUML()
+            svg_bytes = plantuml.generate_to_bytes("svg", diagram_source)
+
+            # Derive a stable, content-addressed file name from the diagram
+            # source so identical diagrams share a single SVG and different
+            # diagrams never collide when several documents are written to the
+            # same output directory (multi-document mode).
+            digest = hashlib.sha1(diagram_source.encode("utf-8")).hexdigest()[:12]
+            local_name = f"plantuml_{digest}.svg"
+            svg_path = os.path.join(Md2ReqifRenderer.image_dir, local_name)
+            with open(svg_path, "wb") as svg_file:
+                svg_file.write(svg_bytes)
+
+            Md2ReqifRenderer.external_files.append((svg_path, local_name))
+
+            result = f'<p><object type="image/svg+xml" data="{html.escape(local_name)}"></object></p>\n'
+        except (FileNotFoundError, OSError) as exc:
+            result = f"<p>[PlantUML error: {html.escape(str(exc))}]</p>\n"
+
+        return result
+
+# Functions ********************************************************************
+
+# Main *************************************************************************

--- a/src/pyTRLCConverter/marko/md2rst_renderer.py
+++ b/src/pyTRLCConverter/marko/md2rst_renderer.py
@@ -23,8 +23,11 @@
 # Imports **********************************************************************
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, cast
+import hashlib
+import os
+from typing import TYPE_CHECKING, Any, cast, Optional
 from marko import Renderer
+from pyTRLCConverter.plantuml import PlantUML
 
 if TYPE_CHECKING:
     from . import block, inline
@@ -36,10 +39,20 @@ if TYPE_CHECKING:
 # pylint: disable-next=too-many-public-methods
 class Md2RstRenderer(Renderer):
     # lobster-trace: SwRequirements.sw_req_rst_render_md
+    # lobster-trace: SwRequirements.sw_req_rst_render_plantuml
+    # lobster-trace: SwRequirements.sw_req_plantuml
+    """Renderer for reStructuredText output.
+
+    Converts CommonMark Markdown to reStructuredText format. Fenced code
+    blocks tagged ``plantuml`` are rendered as SVG images referenced via
+    ``.. image::`` directives.
     """
-    Renderer for reStructuredText output.
-    It is used to convert CommonMark Markdown to reStructuredText format.
-    """
+
+    # Destination directory where generated PNG images are written.
+    image_dir: Optional[str] = None
+
+    # List of ``(source_path, local_name)`` tuples collected during rendering.
+    external_files: Optional[list] = None
 
     def __init__(self) -> None:
         """
@@ -115,8 +128,14 @@ class Md2RstRenderer(Renderer):
         return quoted + "\n\n"
 
     def render_fenced_code(self, element: block.FencedCode) -> str:
-        """
-        Renders a fenced code block element.
+        # lobster-trace: SwRequirements.sw_req_rst_render_md
+        # lobster-trace: SwRequirements.sw_req_plantuml
+        """Render a fenced code block as reStructuredText.
+
+        If the language tag is ``plantuml``, the diagram source is rendered as
+        a PNG image referenced via a ``.. image::`` directive. If PlantUML is
+        not available, an error paragraph is emitted instead. All other fenced
+        code blocks are rendered as ``.. code-block::`` directives.
 
         Args:
             element (block.FencedCode): The fenced code block element to render.
@@ -124,10 +143,54 @@ class Md2RstRenderer(Renderer):
         Returns:
             str: The rendered fenced code block as a string.
         """
+        if element.lang == "plantuml":
+            return self._render_plantuml(element.children[0].children)
+
         lang = element.lang or ""
         code = element.children[0].children  # type: ignore
 
         return f".. code-block:: {lang}\n\n    " + "\n    ".join(code.splitlines()) + "\n\n"
+
+    def _render_plantuml(self, diagram_source: str) -> str:
+        # lobster-trace: SwRequirements.sw_req_rst_render_md
+        # lobster-trace: SwRequirements.sw_req_plantuml
+        """Render a PlantUML diagram as a PNG image reference.
+
+        Generates SVG bytes via the PlantUML tool, writes them to a temporary
+        file under :attr:`image_dir`, registers the file in
+        :attr:`external_files` so the converter can copy it next to the RST
+        document, and returns a ``.. image::`` directive referencing the image
+        by its local name.
+
+        On failure an error paragraph is emitted instead.
+
+        Args:
+            diagram_source (str): The PlantUML diagram source text.
+
+        Returns:
+            str: RST fragment referencing the generated image, or an error
+                paragraph if image generation failed.
+        """
+        assert Md2RstRenderer.image_dir is not None
+        assert Md2RstRenderer.external_files is not None
+
+        try:
+            plantuml = PlantUML()
+            svg_bytes = plantuml.generate_to_bytes("svg", diagram_source)
+
+            digest = hashlib.sha1(diagram_source.encode("utf-8")).hexdigest()[:12]
+            local_name = f"plantuml_{digest}.svg"
+            svg_path = os.path.join(Md2RstRenderer.image_dir, local_name)
+            with open(svg_path, "wb") as svg_file:
+                svg_file.write(svg_bytes)
+
+            Md2RstRenderer.external_files.append((svg_path, local_name))
+
+            result = f".. image:: {local_name}\n\n"
+        except (FileNotFoundError, OSError) as exc:
+            result = f"[PlantUML error: {exc}]\n\n"
+
+        return result
 
     def render_code_block(self, element: block.CodeBlock) -> str:
         """

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -40,7 +40,6 @@ from pyTRLCConverter.logger import log_verbose, log_error
 BASE64_ENCODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 PLANTUML_ENCODE_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_"
 PLANTUML_ENV_VAR = "PLANTUML"
-PLANTUML_VERIFY_SSL_ENV_VAR = "PLANTUML_VERIFY_SSL"
 
 # Classes **********************************************************************
 
@@ -66,10 +65,9 @@ class PlantUML():
                 if urllib.parse.urlparse(plantuml_access).scheme in ['http', 'https']:
                     self._server_url = plantuml_access
                 else:
-                    # Otherwise assume it's a local JAR.
-                    self._plantuml_jar = plantuml_access
+                    self._plantuml_jar = os.environ[PLANTUML_ENV_VAR]
             except ValueError:
-                self._plantuml_jar = plantuml_access
+                self._plantuml_jar = os.environ[PLANTUML_ENV_VAR]
 
     def _get_absolute_path(self, path):
         """Convert a relative path to an absolute path based on the working directory.
@@ -159,8 +157,6 @@ class PlantUML():
         Returns:
             bytes: The raw image bytes.
         """
-        assert diagram_type in ("png", "svg")
-
         if self._server_url is not None:
             result = self._generate_to_bytes_server(diagram_type, diagram_source)
         else:
@@ -181,13 +177,19 @@ class PlantUML():
         Returns:
             bytes: The raw image bytes.
         """
-        with tempfile.NamedTemporaryFile(suffix=".puml", mode='w', encoding='utf-8') as tmp:
-            tmp.write(diagram_source)
-            tmp.flush()
-            url = self._make_server_url(diagram_type, tmp.name)
+        import tempfile  # pylint: disable=import-outside-toplevel
 
-        log_verbose(f"Sending GET request {url}")
-        response = requests.get(url, timeout=10, verify=self._verify_ssl)
+        with tempfile.NamedTemporaryFile(suffix=".puml", mode='w',
+                                        encoding='utf-8', delete=False) as tmp:
+            tmp.write(diagram_source)
+            tmp_path = tmp.name
+
+        try:
+            url = self._make_server_url(diagram_type, tmp_path)
+            log_verbose(f"Sending GET request {url}")
+            response = requests.get(url, timeout=10)
+        finally:
+            os.remove(tmp_path)
 
         if response.status_code != 200:
             raise requests.exceptions.RequestException(
@@ -211,8 +213,7 @@ class PlantUML():
         """
         if self._plantuml_jar is None:
             raise FileNotFoundError(
-                f"PlantUML not found. Set the {PLANTUML_ENV_VAR} environment variable"
-                " to the path of plantuml.jar or a server URL."
+                "plantuml.jar not found, set PLANTUML environment variable."
             )
 
         if not os.path.isfile(self._plantuml_jar):
@@ -238,7 +239,8 @@ class PlantUML():
             )
         except FileNotFoundError as exc:
             raise FileNotFoundError(
-                "Java not found. Ensure Java is installed and available on PATH."
+                "Java is not installed on this machine or not on PATH."
+                " Please check your java install to render PlantUML locally."
             ) from exc
 
         if output.returncode != 0:

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -23,7 +23,6 @@
 import os
 import subprocess
 import sys
-import tempfile
 import zlib
 import base64
 import urllib
@@ -108,19 +107,24 @@ class PlantUML():
 
         return is_plantuml
 
-    def _make_server_url(self, diagram_type: str, diagram_path: str) -> str:
+    def _make_server_url(self, diagram_type: str, diagram_source: str, source_is_file: bool = True) -> str:
         """Generate a PlantUML server GET URL from a diagram data file.
 
         Args:
             diagram_type (str): Diagram type, e.g. svg. See PlantUML -t options.
-            diagram_path (str): Path to the PlantUML diagram.
+            diagram_source (str): Path to the PlantUML diagram or content of PlantUML diagram.
+            source_is_file (bool): True if diagram_source points to a file, False if it is the diagram content.
 
         Raises:
             FileNotFoundError: PlantUML diagram file not found.
         """
-        # Read PlantUML diagram data from given file.
-        with open(diagram_path, 'r', encoding='utf-8') as input_file:
-            diagram_string = input_file.read().encode('utf-8')
+        if source_is_file:
+            # Read PlantUML diagram data from given file.
+            with open(diagram_source, 'r', encoding='utf-8') as input_file:
+                diagram_string = input_file.read().encode('utf-8')
+        else:
+            # Use the provided source directly as the diagram_string.
+            diagram_string = diagram_source.encode('utf-8')
 
         # Compress the data using deflate.
         # Strip Zlib's 2 byte header and 4 byte checksum for raw deflate data.
@@ -181,11 +185,8 @@ class PlantUML():
         Returns:
             bytes: The raw image bytes.
         """
-        with tempfile.NamedTemporaryFile(suffix=".puml", mode='w', encoding='utf-8') as tmp:
-            tmp.write(diagram_source)
-            tmp.flush()
-            url = self._make_server_url(diagram_type, tmp.name)
 
+        url = self._make_server_url(diagram_type, diagram_source, source_is_file=False)
         log_verbose(f"Sending GET request {url}")
         response = requests.get(url, timeout=10, verify=self._verify_ssl)
 

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -65,6 +65,7 @@ class PlantUML():
                 if urllib.parse.urlparse(plantuml_access).scheme in ['http', 'https']:
                     self._server_url = plantuml_access
                 else:
+                    # Otherwise assume it's a local JAR.
                     self._plantuml_jar = os.environ[PLANTUML_ENV_VAR]
             except ValueError:
                 self._plantuml_jar = os.environ[PLANTUML_ENV_VAR]
@@ -213,7 +214,8 @@ class PlantUML():
         """
         if self._plantuml_jar is None:
             raise FileNotFoundError(
-                "plantuml.jar not found, set PLANTUML environment variable."
+                f"PlantUML not found. Set the {PLANTUML_ENV_VAR} environment variable"
+                " to the path of plantuml.jar or a server URL."
             )
 
         if not os.path.isfile(self._plantuml_jar):

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -66,9 +66,9 @@ class PlantUML():
                     self._server_url = plantuml_access
                 else:
                     # Otherwise assume it's a local JAR.
-                    self._plantuml_jar = os.environ[PLANTUML_ENV_VAR]
+                    self._plantuml_jar = plantuml_access
             except ValueError:
-                self._plantuml_jar = os.environ[PLANTUML_ENV_VAR]
+                self._plantuml_jar = plantuml_access
 
     def _get_absolute_path(self, path):
         """Convert a relative path to an absolute path based on the working directory.
@@ -180,17 +180,13 @@ class PlantUML():
         Returns:
             bytes: The raw image bytes.
         """
-        with tempfile.NamedTemporaryFile(suffix=".puml", mode='w',
-                                        encoding='utf-8', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".puml", mode='w', encoding='utf-8') as tmp:
             tmp.write(diagram_source)
-            tmp_path = tmp.name
+            tmp.flush()
+            url = self._make_server_url(diagram_type, tmp.name)
 
-        try:
-            url = self._make_server_url(diagram_type, tmp_path)
-            log_verbose(f"Sending GET request {url}")
-            response = requests.get(url, timeout=10)
-        finally:
-            os.remove(tmp_path)
+        log_verbose(f"Sending GET request {url}")
+        response = requests.get(url, timeout=10)
 
         if response.status_code != 200:
             raise requests.exceptions.RequestException(

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -40,6 +40,7 @@ from pyTRLCConverter.logger import log_verbose, log_error
 BASE64_ENCODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 PLANTUML_ENCODE_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_"
 PLANTUML_ENV_VAR = "PLANTUML"
+PLANTUML_VERIFY_SSL_ENV_VAR = "PLANTUML_VERIFY_SSL"
 
 # Classes **********************************************************************
 
@@ -186,7 +187,7 @@ class PlantUML():
             url = self._make_server_url(diagram_type, tmp.name)
 
         log_verbose(f"Sending GET request {url}")
-        response = requests.get(url, timeout=10)
+        response = requests.get(url, timeout=10, verify=self._verify_ssl)
 
         if response.status_code != 200:
             raise requests.exceptions.RequestException(

--- a/src/pyTRLCConverter/plantuml.py
+++ b/src/pyTRLCConverter/plantuml.py
@@ -158,6 +158,8 @@ class PlantUML():
         Returns:
             bytes: The raw image bytes.
         """
+        assert diagram_type in ("png", "svg")
+
         if self._server_url is not None:
             result = self._generate_to_bytes_server(diagram_type, diagram_source)
         else:
@@ -178,8 +180,6 @@ class PlantUML():
         Returns:
             bytes: The raw image bytes.
         """
-        import tempfile  # pylint: disable=import-outside-toplevel
-
         with tempfile.NamedTemporaryFile(suffix=".puml", mode='w',
                                         encoding='utf-8', delete=False) as tmp:
             tmp.write(diagram_source)
@@ -241,8 +241,7 @@ class PlantUML():
             )
         except FileNotFoundError as exc:
             raise FileNotFoundError(
-                "Java is not installed on this machine or not on PATH."
-                " Please check your java install to render PlantUML locally."
+                "Java not found. Ensure Java is installed and available on PATH."
             ) from exc
 
         if output.returncode != 0:

--- a/src/pyTRLCConverter/reqif_converter.py
+++ b/src/pyTRLCConverter/reqif_converter.py
@@ -25,6 +25,7 @@ import mimetypes
 import os
 import re
 import shutil
+import tempfile
 import zipfile
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -55,6 +56,8 @@ from trlc.ast import (
     Record_Object, Record_Reference, String_Literal, Expression, Symbol_Table
 )
 from pyTRLCConverter.base_converter import BaseConverter
+from pyTRLCConverter.marko.md2reqif_renderer import Md2ReqifRenderer
+from pyTRLCConverter.marko.gfm2reqif_renderer import Gfm2ReqifRenderer
 from pyTRLCConverter.ret import Ret
 from pyTRLCConverter.trlc_helper import TrlcAstWalker
 from pyTRLCConverter.logger import log_error, log_verbose
@@ -96,8 +99,9 @@ class ReqifConverter(BaseConverter):
         super().__init__(args)
 
         self._out_path = args.out
-        self._markdown_renderer_md = Markdown()
-        self._markdown_renderer_gfm = Markdown(extensions=["gfm"])
+        self._markdown_renderer_md = Markdown(renderer=Md2ReqifRenderer)
+        self._markdown_renderer_gfm = Markdown(renderer=Gfm2ReqifRenderer, extensions=["gfm"])
+        self._plantuml_tmp_dir: Optional[tempfile.TemporaryDirectory] = None
 
         self._spec_objects = []
         self._spec_relations = []
@@ -219,6 +223,12 @@ class ReqifConverter(BaseConverter):
         if result == Ret.OK:
             self._empty_attribute_value = self._args.empty
             log_verbose(f"Empty attribute value: {self._empty_attribute_value}")
+
+            # Temporary directory for inline PlantUML images generated while
+            # rendering Markdown attributes. The directory is cleaned up in
+            # finish() once all documents have been written.
+            # pylint: disable-next=consider-using-with
+            self._plantuml_tmp_dir = tempfile.TemporaryDirectory(prefix="pyTRLCConverter_reqif_")
 
             if self._args.single_document is True:
                 log_verbose("Single document mode.")
@@ -392,11 +402,17 @@ class ReqifConverter(BaseConverter):
         Returns:
             Ret: Status
         """
+        result = Ret.OK
+
         if self._args.single_document is True:
             self._flush_pending_hierarchy()
-            return self._write_document(self._args.name)
+            result = self._write_document(self._args.name)
 
-        return Ret.OK
+        if self._plantuml_tmp_dir is not None:
+            self._plantuml_tmp_dir.cleanup()
+            self._plantuml_tmp_dir = None
+
+        return result
 
     def _write_document(self, file_name: str) -> Ret:
         # lobster-trace: SwRequirements.sw_req_reqif_multiple_doc_mode
@@ -1332,10 +1348,16 @@ class ReqifConverter(BaseConverter):
         # lobster-trace: SwRequirements.sw_req_reqif_render_md
         # lobster-trace: SwRequirements.sw_req_reqif_render_gfm
         # lobster-trace: SwRequirements.sw_req_reqif_render_table_options
+        # lobster-trace: SwRequirements.sw_req_reqif_render_plantuml
         """Convert Markdown text to an XHTML-wrapped string using marko.
 
         If ``table_options`` is provided and non-empty, table styling is applied to the
         generated HTML before wrapping (see :meth:`_apply_table_options`).
+
+        Fenced code blocks tagged ``plantuml`` are rendered as embedded SVG
+        images via :class:`Md2ReqifRenderer` / :class:`Gfm2ReqifRenderer`; the
+        generated images are registered in ``self._external_files`` so they are
+        copied next to the ReqIF document.
 
         Args:
             markdown_text (str): Markdown source text.
@@ -1347,6 +1369,14 @@ class ReqifConverter(BaseConverter):
             str: XHTML-wrapped HTML string.
         """
         renderer = self._markdown_renderer_gfm if gfm_mode else self._markdown_renderer_md
+
+        # Wire the inline-PlantUML renderer state to this converter so generated
+        # SVGs are written to the converter's temp directory and tracked in
+        # _external_files for copying.
+        assert self._plantuml_tmp_dir is not None
+        Md2ReqifRenderer.image_dir = self._plantuml_tmp_dir.name
+        Md2ReqifRenderer.external_files = self._external_files
+
         html_text = renderer.convert(markdown_text).strip()
 
         if len(html_text) == 0:

--- a/src/pyTRLCConverter/rst_converter.py
+++ b/src/pyTRLCConverter/rst_converter.py
@@ -21,6 +21,8 @@
 
 # Imports **********************************************************************
 import os
+import shutil
+import tempfile
 from typing import List, Optional, Any
 from marko import Markdown
 from trlc.ast import Implicit_Null, Record_Object, Record_Reference, String_Literal, Expression
@@ -35,6 +37,7 @@ from pyTRLCConverter.marko.gfm2rst_renderer import Gfm2RstRenderer
 
 # Classes **********************************************************************
 
+# pylint: disable-next=too-many-instance-attributes
 class RstConverter(BaseConverter):
     """
     RstConverter provides functionality for converting to a reStructuredText format.
@@ -76,6 +79,9 @@ class RstConverter(BaseConverter):
         # The AST walker meta data for processing the record object fields.
         # This will hold the information about the current package, type and attribute being processed.
         self._ast_meta_data = None
+
+        self._plantuml_tmp_dir: Optional[tempfile.TemporaryDirectory] = None
+        self._external_files: list = []
 
     @staticmethod
     def get_subcommand() -> str:
@@ -184,6 +190,9 @@ class RstConverter(BaseConverter):
 
             log_verbose(f"Empty attribute value: {self._empty_attribute_value}")
 
+            # pylint: disable-next=consider-using-with
+            self._plantuml_tmp_dir = tempfile.TemporaryDirectory(prefix="pyTRLCConverter_rst_")
+
             # Single document mode?
             if self._args.single_document is True:
                 result = self._generate_out_file(self._args.name)
@@ -204,7 +213,7 @@ class RstConverter(BaseConverter):
 
         Args:
             file_name (str): File name
-        
+
         Returns:
             Ret: Status
         """
@@ -237,8 +246,11 @@ class RstConverter(BaseConverter):
         # Multiple document mode?
         if self._args.single_document is False:
             assert self._fd is not None
+            out_dir = os.path.dirname(self._fd.name)
             self._fd.close()
             self._fd = None
+            self._copy_external_files(out_dir)
+            self._external_files = []
 
         return Ret.OK
 
@@ -251,7 +263,7 @@ class RstConverter(BaseConverter):
         Args:
             section (str): The section name
             level (int): The section indentation level
-        
+
         Returns:
             Ret: Status
         """
@@ -279,7 +291,7 @@ class RstConverter(BaseConverter):
             level (int): The record level.
             translation (Optional[dict]): Translation dictionary for the record object.
                                             If None, no translation is applied.
-        
+
         Returns:
             Ret: Status
         """
@@ -298,8 +310,14 @@ class RstConverter(BaseConverter):
         # Single document mode?
         if self._args.single_document is True:
             assert self._fd is not None
+            out_dir = os.path.dirname(self._fd.name)
             self._fd.close()
             self._fd = None
+            self._copy_external_files(out_dir)
+
+        if self._plantuml_tmp_dir is not None:
+            self._plantuml_tmp_dir.cleanup()
+            self._plantuml_tmp_dir = None
 
         return Ret.OK
 
@@ -320,6 +338,27 @@ class RstConverter(BaseConverter):
         else:
             self._fd.write("\n")
 
+    def _copy_external_files(self, dest_dir: str) -> None:
+        # lobster-trace: SwRequirements.sw_req_rst_render_plantuml
+        """Copy all collected external files to the given destination directory.
+
+        Args:
+            dest_dir (str): Destination directory path.
+        """
+        copied_sources = set()
+
+        for source_path, local_name in self._external_files:
+            if source_path in copied_sources:
+                continue
+
+            dest_path = os.path.join(dest_dir, local_name)
+
+            try:
+                shutil.copy2(source_path, dest_path)
+                copied_sources.add(source_path)
+            except (OSError, IOError) as exc:
+                log_error(f"Failed to copy external file '{source_path}': {exc}", False)
+
     def _get_rst_heading_level(self, level: int) -> int:
         # lobster-trace: SwRequirements.sw_req_rst_section
         """
@@ -329,7 +368,7 @@ class RstConverter(BaseConverter):
 
         Args:
             level (int): The TRLC object level.
-        
+
         Returns:
             int: reStructuredText heading level
         """
@@ -342,7 +381,7 @@ class RstConverter(BaseConverter):
 
         Args:
             file_name_trlc (str): TRLC file name
-        
+
         Returns:
             str: reStructuredText file name
         """
@@ -378,11 +417,11 @@ class RstConverter(BaseConverter):
 
         return result
 
-    def _on_implict_null(self, _: Implicit_Null) -> str:
+    def _on_implicit_null(self, _: Implicit_Null) -> str:
         # lobster-trace: SwRequirements.sw_req_rst_record
         """
         Process the given implicit null value.
-        
+
         Returns:
             str: The implicit null value.
         """
@@ -395,7 +434,7 @@ class RstConverter(BaseConverter):
 
         Args:
             record_reference (Record_Reference): The record reference value.
-        
+
         Returns:
             str: reStructuredText link to the record reference.
         """
@@ -410,7 +449,7 @@ class RstConverter(BaseConverter):
 
         Args:
             string_literal (String_Literal): The string literal value.
-        
+
         Returns:
             str: The string literal value.
         """
@@ -495,7 +534,7 @@ class RstConverter(BaseConverter):
         trlc_ast_walker.add_dispatcher(
             Implicit_Null,
             None,
-            self._on_implict_null,
+            self._on_implicit_null,
             None
         )
         trlc_ast_walker.add_dispatcher(
@@ -518,7 +557,8 @@ class RstConverter(BaseConverter):
         # lobster-trace: SwRequirements.sw_req_rst_string_format
         # lobster-trace: SwRequirements.sw_req_rst_render_md
         # lobster-trace: SwRequirements.sw_req_rst_render_gfm
-        """Render the attribute value depened on its format.
+        # lobster-trace: SwRequirements.sw_req_rst_render_plantuml
+        """Render the attribute value depending on its format.
 
         Args:
             package_name (str): The package name.
@@ -536,13 +576,17 @@ class RstConverter(BaseConverter):
 
             # Is it CommonMark Markdown format?
             if self._render_cfg.is_format_md(package_name, type_name, attribute_name) is True:
-                # Convert Markdown to reStructuredText.
+                assert self._plantuml_tmp_dir is not None
+                Md2RstRenderer.image_dir = self._plantuml_tmp_dir.name
+                Md2RstRenderer.external_files = self._external_files
                 markdown = Markdown(renderer=Md2RstRenderer)
                 result = markdown.convert(attribute_value)
 
             # Is it GitHub Flavored Markdown format?
             elif self._render_cfg.is_format_gfm(package_name, type_name, attribute_name) is True:
-                # Convert GitHub Flavored Markdown to reStructuredText.
+                assert self._plantuml_tmp_dir is not None
+                Md2RstRenderer.image_dir = self._plantuml_tmp_dir.name
+                Md2RstRenderer.external_files = self._external_files
                 markdown = Markdown(renderer=Gfm2RstRenderer, extensions=['gfm'])
                 result = markdown.convert(attribute_value)
 
@@ -563,7 +607,7 @@ class RstConverter(BaseConverter):
             level (int): The record level.
             translation (Optional[dict]): Translation dictionary for the record object.
                                             If None, no translation is applied.
-        
+
             Returns:
             Ret: Status
         """
@@ -794,7 +838,7 @@ class RstConverter(BaseConverter):
         Args:
             list_values (List[str]): List of list values.
             escape (bool): Escapes every list value (default: True).
-        
+
         Returns:
             str: reStructuredText list
         """

--- a/tests/test_docx.py
+++ b/tests/test_docx.py
@@ -114,7 +114,7 @@ def test_tc_docx_multiple(record_property, capsys, monkeypatch, tmp_path):
     assert created_docx.tables[1].cell(2, 0).text == "link"
     assert created_docx.tables[1].cell(2, 1).text == "Requirements.req_id_5"
 
-    # Check that the hyperlink anchors were correctly set. Cells paragraph needs to hold a hyperlink with orrect anchor.
+    # Check that the hyperlink anchors were correctly set. Cells paragraph needs to hold a hyperlink with correct anchor.
     assert created_docx.tables[0].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_6" # pylint: disable=protected-access
     assert created_docx.tables[1].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_5" # pylint: disable=protected-access
 
@@ -194,7 +194,7 @@ def test_tc_docx_file(record_property, capsys, monkeypatch, tmp_path):
     # Check that the first requirement is present.
     assert created_docx.paragraphs[0].text == "req_id_1 (Requirement)"
     # Paragraph 1 is the "from file" paragraph.
-    # Check the secont requirement is present.
+    # Check the second requirement is present.
     assert created_docx.paragraphs[2].text == "Test section"
     assert created_docx.paragraphs[3].text == "req_id_2 (Requirement)"
 

--- a/tests/test_docx.py
+++ b/tests/test_docx.py
@@ -19,8 +19,9 @@
 
 # Imports **********************************************************************
 
-import docx
 from unittest.mock import patch
+
+import docx
 
 from pyTRLCConverter.__main__ import main
 from pyTRLCConverter.docx_converter import DocxConverter
@@ -114,7 +115,8 @@ def test_tc_docx_multiple(record_property, capsys, monkeypatch, tmp_path):
     assert created_docx.tables[1].cell(2, 0).text == "link"
     assert created_docx.tables[1].cell(2, 1).text == "Requirements.req_id_5"
 
-    # Check that the hyperlink anchors were correctly set. Cells paragraph needs to hold a hyperlink with correct anchor.
+    # Check that the hyperlink anchors were correctly set.
+    # Cells paragraph needs to hold a hyperlink with correct anchor.
     assert created_docx.tables[0].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_6" # pylint: disable=protected-access
     assert created_docx.tables[1].cell(2, 1).paragraphs[0]._p.hyperlink_lst[0].anchor == "req_id_5" # pylint: disable=protected-access
 

--- a/tests/test_docx.py
+++ b/tests/test_docx.py
@@ -20,6 +20,7 @@
 # Imports **********************************************************************
 
 import docx
+from unittest.mock import patch
 
 from pyTRLCConverter.__main__ import main
 from pyTRLCConverter.docx_converter import DocxConverter
@@ -437,3 +438,115 @@ def test_tc_docx_render_gfm(record_property, capsys, monkeypatch, tmp_path):
         for p in description_cell.paragraphs
     )
     assert plantuml_rendered, "PlantUML block not rendered (no image and no error string)"
+
+
+def test_tc_docx_render_plantuml(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_docx_render_plantuml
+    """A plantuml fenced code block in a Markdown attribute shall be rendered as an embedded
+    PNG image in the docx output.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Any): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_docx_render_plantuml")
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfgDocxMd.json",
+        "docx",
+        "--template", "./tests/utils/template.docx",
+    ])
+
+    # Provide a minimal valid 1x1 white PNG so python-docx can embed it.
+    png_1x1 = (
+        b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
+        b'\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xff\xff?'
+        b'\x00\x05\xfe\x02\xfe\r\xefF\xb8\x00\x00\x00\x00IEND\xaeB`\x82'
+    )
+
+    def _fake_generate(_fmt, src, _dst):
+        png_path = src.replace(".puml", ".png")
+        with open(png_path, "wb") as f:
+            f.write(png_1x1)
+
+    with patch("pyTRLCConverter.marko.md2docx_renderer.PlantUML.generate",
+               side_effect=_fake_generate):
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    created_docx = docx.Document(docx=str(tmp_path / DocxConverter.OUTPUT_FILE_NAME_DEFAULT))
+    ns = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+
+    description_cell = None
+    for table in created_docx.tables:
+        for row in table.rows:
+            if row.cells[0].text == "description":
+                description_cell = row.cells[1]
+                break
+        if description_cell is not None:
+            break
+
+    assert description_cell is not None, "description cell not found"
+
+    image_found = any(
+        any(run.element.findall(f'.//{{{ns}}}drawing') for run in p.runs)
+        for p in description_cell.paragraphs
+    )
+    assert image_found, "No embedded image found in docx output for plantuml block"
+
+
+def test_tc_docx_render_plantuml_error(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_docx_render_plantuml
+    """If PlantUML is not available, a plantuml fenced code block shall be replaced by a
+    [PlantUML error: ...] paragraph instead of failing the conversion.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Any): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_docx_render_plantuml")
+
+    monkeypatch.delenv("PLANTUML", raising=False)
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfgDocxMd.json",
+        "docx",
+        "--template", "./tests/utils/template.docx",
+    ])
+
+    main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    created_docx = docx.Document(docx=str(tmp_path / DocxConverter.OUTPUT_FILE_NAME_DEFAULT))
+
+    description_cell = None
+    for table in created_docx.tables:
+        for row in table.rows:
+            if row.cells[0].text == "description":
+                description_cell = row.cells[1]
+                break
+        if description_cell is not None:
+            break
+
+    assert description_cell is not None, "description cell not found"
+
+    error_found = any("[PlantUML error:" in p.text for p in description_cell.paragraphs)
+    assert error_found, "No [PlantUML error:] paragraph found in docx output"
+
+# Main *************************************************************************

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -21,6 +21,7 @@
 import os
 from argparse import Namespace
 from collections import namedtuple
+from unittest.mock import patch
 
 from pyTRLCConverter.__main__ import main
 from pyTRLCConverter.markdown_converter import MarkdownConverter
@@ -834,3 +835,93 @@ https://github.com/NewTec-GmbH/pyTRLCConverter
                                      ["index", "N/A"],
                                      ["precision", "N/A"],
                                      ["valid", "N/A"]])
+
+
+def test_tc_markdown_render_plantuml(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_markdown_render_plantuml
+    """A plantuml fenced code block shall be replaced by an SVG image reference when
+    --render-plantuml is given, and the SVG file shall be written to the output folder.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Any): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_markdown_render_plantuml")
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfg.json",
+        "markdown",
+        "--single-document",
+        "--render-plantuml",
+    ])
+
+    svg_payload = (
+        b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>'
+    )
+    with patch("pyTRLCConverter.markdown_converter.PlantUML.generate_to_bytes",
+               return_value=svg_payload):
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    md_content = (tmp_path / MarkdownConverter.OUTPUT_FILE_NAME_DEFAULT).read_text(encoding="utf-8")
+
+    assert "![](plantuml_" in md_content
+    assert "```plantuml" not in md_content
+
+    svg_files = [f for f in os.listdir(tmp_path)
+                 if f.startswith("plantuml_") and f.endswith(".svg")]
+    assert len(svg_files) == 1
+    assert svg_files[0] in md_content
+    assert (tmp_path / svg_files[0]).read_bytes() == svg_payload
+
+
+def test_tc_markdown_render_plantuml_error(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_markdown_render_plantuml_error
+    """When --render-plantuml is given but PlantUML is not available, a plantuml fenced
+    code block shall be replaced by a [PlantUML error: ...] paragraph.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Any): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_markdown_render_plantuml_error")
+
+    monkeypatch.delenv("PLANTUML", raising=False)
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfg.json",
+        "markdown",
+        "--single-document",
+        "--render-plantuml",
+    ])
+
+    main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    md_content = (tmp_path / MarkdownConverter.OUTPUT_FILE_NAME_DEFAULT).read_text(encoding="utf-8")
+
+    assert "[PlantUML error:" in md_content
+    assert "```plantuml" not in md_content
+
+    svg_files = [f for f in os.listdir(tmp_path)
+                 if f.startswith("plantuml_") and f.endswith(".svg")]
+    assert len(svg_files) == 0
+
+# Main *************************************************************************

--- a/tests/test_plantuml.py
+++ b/tests/test_plantuml.py
@@ -79,9 +79,16 @@ def test_make_server_url(record_property, plantuml_instance: PlantUML):
     expected_url = "http://plantuml.com/plantuml/svg/SoWkIImgAStDuNBCoKnELT2rKt3AJx9Iy4ZDoSddSaZDIm7A0G0%3D"
 
     mock_diagram_content = "@startuml\nAlice -> Bob: Hello\n@enduml"
+
+    # Test the URL creation when reading the diagram_content from a file.
     with patch("builtins.open", mock_open(read_data=mock_diagram_content)):
         result_url = plantuml_instance._make_server_url(diagram_type, diagram_path)
 
+    assert result_url.startswith("http://plantuml.com/plantuml/svg/")
+    assert result_url == expected_url
+
+    # Repeat the test by giving the diagram_content directly to the function.
+    result_url = plantuml_instance._make_server_url(diagram_type, mock_diagram_content, source_is_file=False)
     assert result_url.startswith("http://plantuml.com/plantuml/svg/")
     assert result_url == expected_url
 

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -20,6 +20,7 @@
 import os
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 from pyTRLCConverter.__main__ import main
 from pyTRLCConverter.reqif_converter import ReqifConverter
 from tests.reqif_test_utils import (
@@ -548,5 +549,121 @@ def test_tc_reqif_reqifz_multiple_doc(record_property, capsys, monkeypatch, tmp_
             names = zf.namelist()
             assert len(names) == 1
             assert names[0] == doc_name + ".reqif"
+
+
+def test_tc_reqif_render_plantuml(record_property, capsys, monkeypatch, tmp_path: Path):
+    # lobster-trace: SwTests.tc_reqif_render_plantuml
+    """A plantuml fenced code block in a Markdown attribute shall be rendered as an XHTML <object>
+    referencing a generated SVG file copied to the output folder.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Path): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_reqif_render_plantuml")
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfg.json",
+        "reqif",
+        "--single-document"
+    ])
+
+    # Mock PlantUML so the test does not depend on Java or a PlantUML server being
+    # available in the test environment.
+    svg_payload = (
+        b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>'
+    )
+    with patch("pyTRLCConverter.marko.md2reqif_renderer.PlantUML.generate_to_bytes",
+               return_value=svg_payload):
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    output_file = os.path.join(tmp_path, ReqifConverter.OUTPUT_FILE_NAME_DEFAULT)
+    bundle = _parse_reqif(output_file)
+
+    spec_object = _find_spec_object_by_long_name(bundle, "req_id_md")
+    assert spec_object is not None
+
+    description_identifier = _find_attribute_identifier(bundle, "description")
+    assert description_identifier is not None
+
+    description_attribute = _find_attribute_by_identifier(spec_object, description_identifier)
+    assert description_attribute is not None
+
+    # The XHTML must reference the generated SVG via an <object> element.
+    assert 'type="image/svg+xml"' in description_attribute.value
+    assert '<object' in description_attribute.value
+
+    # Exactly one SVG file must have been copied to the output folder. Its
+    # local name is content-addressed, so we just verify any plantuml_*.svg
+    # exists and is referenced from the XHTML.
+    svg_files = [name for name in os.listdir(tmp_path)
+                 if name.startswith("plantuml_") and name.endswith(".svg")]
+    assert len(svg_files) == 1
+    assert f'data="{svg_files[0]}"' in description_attribute.value
+
+    # And the file on disk must contain the mocked SVG payload.
+    with open(os.path.join(tmp_path, svg_files[0]), "rb") as svg_file:
+        assert svg_file.read() == svg_payload
+
+
+def test_tc_reqif_render_plantuml_error(record_property, capsys, monkeypatch, tmp_path: Path):
+    # lobster-trace: SwTests.tc_reqif_render_plantuml_error
+    """If PlantUML is not available, a plantuml fenced code block shall be replaced by a
+    [PlantUML error: ...] paragraph instead of failing the conversion.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Path): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_reqif_render_plantuml_error")
+
+    # Ensure PlantUML is not configured for this test run.
+    monkeypatch.delenv("PLANTUML", raising=False)
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfg.json",
+        "reqif",
+        "--single-document"
+    ])
+
+    main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    output_file = os.path.join(tmp_path, ReqifConverter.OUTPUT_FILE_NAME_DEFAULT)
+    bundle = _parse_reqif(output_file)
+
+    spec_object = _find_spec_object_by_long_name(bundle, "req_id_md")
+    assert spec_object is not None
+
+    description_identifier = _find_attribute_identifier(bundle, "description")
+    assert description_identifier is not None
+
+    description_attribute = _find_attribute_by_identifier(spec_object, description_identifier)
+    assert description_attribute is not None
+
+    # The plantuml block must be replaced by a [PlantUML error: ...] paragraph.
+    assert "[PlantUML error:" in description_attribute.value
+    # And no SVG file may have been written to the output folder.
+    svg_files = [name for name in os.listdir(tmp_path)
+                 if name.startswith("plantuml_") and name.endswith(".svg")]
+    assert len(svg_files) == 0
 
 # Main *************************************************************************

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -1,5 +1,6 @@
 """Test the reStructuredText requirements.
 """
+# pylint: disable=too-many-lines
 
 # pyTRLCConverter - A tool to convert TRLC files to specific formats.
 # Copyright (c) 2024 - 2026 NewTec GmbH

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -19,6 +19,7 @@
 
 # Imports **********************************************************************
 import os
+from unittest.mock import patch
 
 from argparse import Namespace
 from collections import namedtuple
@@ -672,8 +673,13 @@ def test_tc_rst_render_md(record_property, capsys, monkeypatch, tmp_path):
         "--name", output_file_name
     ])
 
-    # Expect the program to run without any exceptions.
-    main()
+    svg_payload = (
+        b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>'
+    )
+    with patch("pyTRLCConverter.marko.md2rst_renderer.PlantUML.generate_to_bytes",
+               return_value=svg_payload):
+        main()
 
     # Capture stdout and stderr.
     captured = capsys.readouterr()
@@ -738,34 +744,30 @@ def test_tc_rst_render_md(record_property, capsys, monkeypatch, tmp_path):
         assert lines[51] == "    |                |     Code block example                                                      |\n"
         assert lines[52] == "    |                |                                                                             |\n"
         assert lines[53] == "    |                |                                                                             |\n"
-        assert lines[54] == "    |                | .. code-block:: plantuml                                                    |\n"
+        assert ".. image:: plantuml_" in lines[54]
+        assert lines[54].endswith(".svg                                        |\n")
         assert lines[55] == "    |                |                                                                             |\n"
-        assert lines[56] == "    |                |     @startuml                                                               |\n"
-        assert lines[57] == "    |                |     Alice -> Bob: Hello                                                     |\n"
-        assert lines[58] == "    |                |     Bob --> Alice: Hi                                                       |\n"
-        assert lines[59] == "    |                |     @enduml                                                                 |\n"
+        assert lines[56] == "    |                |                                                                             |\n"
+        assert lines[57] == "    |                |                                                                             |\n"
+        assert lines[58] == "    |                | ----                                                                        |\n"
+        assert lines[59] == "    |                |                                                                             |\n"
         assert lines[60] == "    |                |                                                                             |\n"
-        assert lines[61] == "    |                |                                                                             |\n"
+        assert lines[61] == "    |                |   Blockquote example                                                        |\n"
         assert lines[62] == "    |                |                                                                             |\n"
-        assert lines[63] == "    |                | ----                                                                        |\n"
+        assert lines[63] == "    |                |                                                                             |\n"
         assert lines[64] == "    |                |                                                                             |\n"
-        assert lines[65] == "    |                |                                                                             |\n"
-        assert lines[66] == "    |                |   Blockquote example                                                        |\n"
+        assert lines[65] == "    |                | `Link to pyTRLCConverter <https://github.com/NewTec-GmbH/pyTRLCConverter>`_ |\n"
+        assert lines[66] == "    |                |                                                                             |\n"
         assert lines[67] == "    |                |                                                                             |\n"
-        assert lines[68] == "    |                |                                                                             |\n"
-        assert lines[69] == "    |                |                                                                             |\n"
-        assert lines[70] == "    |                | `Link to pyTRLCConverter <https://github.com/NewTec-GmbH/pyTRLCConverter>`_ |\n"
-        assert lines[71] == "    |                |                                                                             |\n"
-        assert lines[72] == "    |                |                                                                             |\n"
-        assert lines[73] == "    +----------------+-----------------------------------------------------------------------------+\n"
-        assert lines[74] == "    | link           | N/A                                                                         |\n"
-        assert lines[75] == "    +----------------+-----------------------------------------------------------------------------+\n"
-        assert lines[76] == "    | index          | N/A                                                                         |\n"
-        assert lines[77] == "    +----------------+-----------------------------------------------------------------------------+\n"
-        assert lines[78] == "    | precision      | N/A                                                                         |\n"
-        assert lines[79] == "    +----------------+-----------------------------------------------------------------------------+\n"
-        assert lines[80] == "    | valid          | N/A                                                                         |\n"
-        assert lines[81] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[68] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[69] == "    | link           | N/A                                                                         |\n"
+        assert lines[70] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[71] == "    | index          | N/A                                                                         |\n"
+        assert lines[72] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[73] == "    | precision      | N/A                                                                         |\n"
+        assert lines[74] == "    +----------------+-----------------------------------------------------------------------------+\n"
+        assert lines[75] == "    | valid          | N/A                                                                         |\n"
+        assert lines[76] == "    +----------------+-----------------------------------------------------------------------------+\n"
 
 # pylint: disable-next=too-many-statements
 def test_tc_rst_render_gfm(record_property, capsys, monkeypatch, tmp_path):
@@ -794,8 +796,13 @@ def test_tc_rst_render_gfm(record_property, capsys, monkeypatch, tmp_path):
         "--name", output_file_name
     ])
 
-    # Expect the program to run without any exceptions.
-    main()
+    svg_payload = (
+        b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>'
+    )
+    with patch("pyTRLCConverter.marko.md2rst_renderer.PlantUML.generate_to_bytes",
+               return_value=svg_payload):
+        main()
 
     # Capture stdout and stderr.
     captured = capsys.readouterr()
@@ -868,44 +875,129 @@ def test_tc_rst_render_gfm(record_property, capsys, monkeypatch, tmp_path):
         assert lines[58] == "    |                |     Code block example                                                                             |\n"
         assert lines[59] == "    |                |                                                                                                    |\n"
         assert lines[60] == "    |                |                                                                                                    |\n"
-        assert lines[61] == "    |                | .. code-block:: plantuml                                                                           |\n"
+        assert ".. image:: plantuml_" in lines[61]
+        assert lines[61].endswith(".svg                                                               |\n")
         assert lines[62] == "    |                |                                                                                                    |\n"
-        assert lines[63] == "    |                |     @startuml                                                                                      |\n"
-        assert lines[64] == "    |                |     Alice -> Bob: Hello                                                                            |\n"
-        assert lines[65] == "    |                |     Bob --> Alice: Hi                                                                              |\n"
-        assert lines[66] == "    |                |     @enduml                                                                                        |\n"
+        assert lines[63] == "    |                |                                                                                                    |\n"
+        assert lines[64] == "    |                |                                                                                                    |\n"
+        assert lines[65] == "    |                | ----                                                                                               |\n"
+        assert lines[66] == "    |                |                                                                                                    |\n"
         assert lines[67] == "    |                |                                                                                                    |\n"
-        assert lines[68] == "    |                |                                                                                                    |\n"
+        assert lines[68] == "    |                | `https://github.com/NewTec-GmbH/pyTRLCConverter <https://github.com/NewTec-GmbH/pyTRLCConverter>`_ |\n"
         assert lines[69] == "    |                |                                                                                                    |\n"
-        assert lines[70] == "    |                | ----                                                                                               |\n"
-        assert lines[71] == "    |                |                                                                                                    |\n"
+        assert lines[70] == "    |                |                                                                                                    |\n"
+        assert lines[71] == "    |                |   Blockquote example                                                                               |\n"
         assert lines[72] == "    |                |                                                                                                    |\n"
-        assert lines[73] == "    |                | `https://github.com/NewTec-GmbH/pyTRLCConverter <https://github.com/NewTec-GmbH/pyTRLCConverter>`_ |\n"
+        assert lines[73] == "    |                |                                                                                                    |\n"
         assert lines[74] == "    |                |                                                                                                    |\n"
-        assert lines[75] == "    |                |                                                                                                    |\n"
-        assert lines[76] == "    |                |   Blockquote example                                                                               |\n"
+        assert lines[75] == "    |                | `Link to pyTRLCConverter <https://github.com/NewTec-GmbH/pyTRLCConverter>`_                        |\n"
+        assert lines[76] == "    |                |                                                                                                    |\n"
         assert lines[77] == "    |                |                                                                                                    |\n"
-        assert lines[78] == "    |                |                                                                                                    |\n"
-        assert lines[79] == "    |                |                                                                                                    |\n"
-        assert lines[80] == "    |                | `Link to pyTRLCConverter <https://github.com/NewTec-GmbH/pyTRLCConverter>`_                        |\n"
-        assert lines[81] == "    |                |                                                                                                    |\n"
-        assert lines[82] == "    |                |                                                                                                    |\n"
-        assert lines[83] == "    |                | +-------+-------+                                                                                  |\n"
-        assert lines[84] == "    |                | | Col 0 | Col 1 |                                                                                  |\n"
-        assert lines[85] == "    |                | +=======+=======+                                                                                  |\n"
-        assert lines[86] == "    |                | | A     | B     |                                                                                  |\n"
-        assert lines[87] == "    |                | +-------+-------+                                                                                  |\n"
-        assert lines[88] == "    |                |                                                                                                    |\n"
-        assert lines[89] == "    |                |                                                                                                    |\n"
-        assert lines[90] == "    |                | ~~I am strikethrough.~~                                                                            |\n"
-        assert lines[91] == "    |                |                                                                                                    |\n"
-        assert lines[92] == "    |                |                                                                                                    |\n"
-        assert lines[93] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
-        assert lines[94] == "    | link           | N/A                                                                                                |\n"
-        assert lines[95] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
-        assert lines[96] == "    | index          | N/A                                                                                                |\n"
-        assert lines[97] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
-        assert lines[98] == "    | precision      | N/A                                                                                                |\n"
-        assert lines[99] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
-        assert lines[100] == "    | valid          | N/A                                                                                                |\n"
-        assert lines[101] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
+        assert lines[78] == "    |                | +-------+-------+                                                                                  |\n"
+        assert lines[79] == "    |                | | Col 0 | Col 1 |                                                                                  |\n"
+        assert lines[80] == "    |                | +=======+=======+                                                                                  |\n"
+        assert lines[81] == "    |                | | A     | B     |                                                                                  |\n"
+        assert lines[82] == "    |                | +-------+-------+                                                                                  |\n"
+        assert lines[83] == "    |                |                                                                                                    |\n"
+        assert lines[84] == "    |                |                                                                                                    |\n"
+        assert lines[85] == "    |                | ~~I am strikethrough.~~                                                                            |\n"
+        assert lines[86] == "    |                |                                                                                                    |\n"
+        assert lines[87] == "    |                |                                                                                                    |\n"
+        assert lines[88] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
+        assert lines[89] == "    | link           | N/A                                                                                                |\n"
+        assert lines[90] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
+        assert lines[91] == "    | index          | N/A                                                                                                |\n"
+        assert lines[92] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
+        assert lines[93] == "    | precision      | N/A                                                                                                |\n"
+        assert lines[94] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
+        assert lines[95] == "    | valid          | N/A                                                                                                |\n"
+        assert lines[96] == "    +----------------+----------------------------------------------------------------------------------------------------+\n"
+
+
+def test_tc_rst_render_plantuml(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_rst_render_plantuml
+    """A plantuml fenced code block in a Markdown attribute shall be rendered as a
+    reStructuredText ``.. image::`` directive referencing a generated SVG file copied
+    to the output folder.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Path): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_rst_render_plantuml")
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfg.json",
+        "rst",
+        "--single-document",
+    ])
+
+    svg_payload = (
+        b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>'
+    )
+
+    with patch("pyTRLCConverter.marko.md2rst_renderer.PlantUML.generate_to_bytes",
+               return_value=svg_payload):
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    rst_content = (tmp_path / RstConverter.OUTPUT_FILE_NAME_DEFAULT).read_text(encoding="utf-8")
+
+    assert ".. image::" in rst_content
+
+    svg_files = [f for f in os.listdir(tmp_path)
+                 if f.startswith("plantuml_") and f.endswith(".svg")]
+    assert len(svg_files) == 1
+    assert svg_files[0] in rst_content
+
+    assert (tmp_path / svg_files[0]).read_bytes() == svg_payload
+
+
+def test_tc_rst_render_plantuml_error(record_property, capsys, monkeypatch, tmp_path):
+    # lobster-trace: SwTests.tc_rst_render_plantuml_error
+    """If PlantUML is not available, a plantuml fenced code block shall be replaced by a
+    [PlantUML error: ...] paragraph instead of failing the conversion.
+
+    Args:
+        record_property (Any): Used to inject the test case reference into the test results.
+        capsys (Any): Used to capture stdout and stderr.
+        monkeypatch (Any): Used to mock program arguments.
+        tmp_path (Path): Used to create a temporary output directory.
+    """
+    record_property("lobster-trace", "SwTests.tc_rst_render_plantuml_error")
+
+    monkeypatch.delenv("PLANTUML", raising=False)
+
+    monkeypatch.setattr("sys.argv", [
+        "pyTRLCConverter",
+        "--source", "./tests/utils/req.rsl",
+        "--source", "./tests/utils/single_req_description_md.trlc",
+        "--out", str(tmp_path),
+        "--renderCfg", "./tests/utils/renderCfg.json",
+        "rst",
+        "--single-document",
+    ])
+
+    main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    rst_content = (tmp_path / RstConverter.OUTPUT_FILE_NAME_DEFAULT).read_text(encoding="utf-8")
+
+    assert "[PlantUML error:" in rst_content
+
+    svg_files = [f for f in os.listdir(tmp_path)
+                 if f.startswith("plantuml_") and f.endswith(".svg")]
+    assert len(svg_files) == 0
+
+# Main *************************************************************************

--- a/trlc/swe-arch/swe-arch.trlc
+++ b/trlc/swe-arch/swe-arch.trlc
@@ -297,6 +297,7 @@ section "SW Architecture" {
 
                     * Registers the `markdown` output format and options
                     * Prints sections and records in markdown
+                    * Optionally renders inline PlantUML fenced code blocks as SVG image references when `--render-plantuml` is given.
                     """
                 verification_criteria = "Call the tool using the `pyTRLCConverter` frontend with markdown output format."
                 satisfies = [
@@ -322,6 +323,8 @@ section "SW Architecture" {
                     SwRequirements.sw_req_markdown_top_level_custom,
                     SwRequirements.sw_req_markdown_render_md,
                     SwRequirements.sw_req_markdown_render_gfm,
+                    SwRequirements.sw_req_markdown_render_plantuml,
+                    SwRequirements.sw_req_cli_render_plantuml,
                     SwRequirements.sw_req_markdown_out_file_name_default,
                     SwRequirements.sw_req_destination_format
                 ]

--- a/trlc/swe-arch/swe-arch.trlc
+++ b/trlc/swe-arch/swe-arch.trlc
@@ -339,6 +339,7 @@ section "SW Architecture" {
 
                     * Registers the `rst` output format and options
                     * Prints sections and records in ReStructuredText
+                    * Renders inline PlantUML fenced code blocks as SVG images referenced via `.. image::` directives.
                     """
                 verification_criteria = "Call the tool using the `pyTRLCConverter` frontend with rst output format."
                 satisfies = [
@@ -364,6 +365,7 @@ section "SW Architecture" {
                     SwRequirements.sw_req_rst_sd_top_level_custom,
                     SwRequirements.sw_req_rst_render_md,
                     SwRequirements.sw_req_rst_render_gfm,
+                    SwRequirements.sw_req_rst_render_plantuml,
                     SwRequirements.sw_req_destination_format
                 ]
             }
@@ -426,6 +428,7 @@ section "SW Architecture" {
 
                     * Registers the `docx` output format and options.
                     * Creates sections and records in docx format.
+                    * Renders inline PlantUML fenced code blocks as embedded PNG images.
                     """
                 verification_criteria = "Call the tool using the `pyTRLCConverter` frontend with docx output format."
                 satisfies = [
@@ -437,6 +440,7 @@ section "SW Architecture" {
                     SwRequirements.sw_req_docx_reference,
                     SwRequirements.sw_req_docx_render_md,
                     SwRequirements.sw_req_docx_render_gfm,
+                    SwRequirements.sw_req_docx_render_plantuml,
                     SwRequirements.sw_req_destination_format
                 ]
             }

--- a/trlc/swe-arch/swe-arch.trlc
+++ b/trlc/swe-arch/swe-arch.trlc
@@ -382,6 +382,7 @@ section "SW Architecture" {
                     * Creates sections and records in ReqIF format.
                     * Converts configured CommonMark and GFM fields into ReqIF XHTML.
                     * Passes configured XHTML fields through to ReqIF XHTML without modification.
+                    * Renders inline PlantUML fenced code blocks as embedded SVG images in XHTML attributes.
                     * Converts TRLC enumeration type attributes to DATATYPE-DEFINITION-ENUMERATION with 0-based consecutive ENUM-VALUE keys in RSL declaration order.
                     * Omits optional enumeration attributes with null value from the generated spec-object.
                     * Converts TRLC record reference attributes to ReqIF SPEC-RELATION entries.
@@ -403,6 +404,7 @@ section "SW Architecture" {
                     SwRequirements.sw_req_reqif_render_xhtml,
                     SwRequirements.sw_req_reqif_render_path,
                     SwRequirements.sw_req_reqif_render_table_options,
+                    SwRequirements.sw_req_reqif_render_plantuml,
                     SwRequirements.sw_req_reqif_enum,
                     SwRequirements.sw_req_reqif_enum_key_order,
                     SwRequirements.sw_req_reqif_enum_null,

--- a/trlc/swe-req/swe-req.trlc
+++ b/trlc/swe-req/swe-req.trlc
@@ -41,12 +41,12 @@ section "SW Requirements" {
                 description = "The software shall support the requirement type attribute name translation via a translation file in JSON format."
                 verification_criteria = "Verify by converting one or more TRLC files with a translation file."
                 valid_status = AbstractRequirements.VALID_STATUS.valid
-                note = "Some attribute names may contain underscores or other special characters. These shall be translated to a humand readable names."
+                note = "Some attribute names may contain underscores or other special characters. These shall be translated to a human readable names."
             }
 
             SwReq sw_req_render_configuration {
-                description = "The software shall support to specify the format of a string literal via a render configuration in JSON format."
-                verification_criteria = "Verify by converting one or more TRLC files with a render configuration file."
+                description = "The software shall allow the format of string attributes to be declared per `(package, type, attribute)` pattern via a JSON render configuration file. Supported formats are: `md` (CommonMark), `gfm` (GitHub Flavored Markdown), `rst` (reStructuredText), `xhtml`, and `path` (file-system path to an external image)."
+                verification_criteria = "Verify that each supported format token is correctly recognized and applied when a render configuration file is provided."
                 valid_status = AbstractRequirements.VALID_STATUS.valid
             }
 
@@ -147,7 +147,7 @@ section "SW Requirements" {
                 description = "The software shall support the command line argument '-ex' and '--exclude' multiple times to specify the file(s) for automatic exclusion."
                 verification_criteria = "Verify by calling the software with the argument '--exclude' and check if the file(s) are excluded."
                 valid_status = AbstractRequirements.VALID_STATUS.valid
-                note = "This is necessary in case an defined archtecture element traces to a requirement, but the requirement should not be included in the output."
+                note = "This is necessary in case an defined architecture element traces to a requirement, but the requirement should not be included in the output."
             }
 
             SwReq sw_req_no_prj_spec {
@@ -172,6 +172,13 @@ section "SW Requirements" {
                 description = "The software shall support the command line argument '-rc' and '--renderCfg' to specify the render configuration JSON file."
                 verification_criteria = "Verify by calling the software with the argument '--renderCfg' and check if e.g. Markdown is rendered correctly for string literals."
                 valid_status = AbstractRequirements.VALID_STATUS.valid
+            }
+
+            SwReq sw_req_cli_render_plantuml {
+                description = "The Markdown subcommand shall support the command line argument '--render-plantuml' to opt in to rendering plantuml fenced code blocks as SVG image references."
+                verification_criteria = "Verify by calling the Markdown converter with '--render-plantuml' and check that plantuml blocks are replaced by SVG image references."
+                valid_status = AbstractRequirements.VALID_STATUS.valid
+                derived = [sw_req_markdown_render_plantuml]
             }
         }
 
@@ -324,6 +331,12 @@ section "SW Requirements" {
                     verification_criteria = "Verify by using strings in Markdown format according to GitHub Flavored Markdown spec, which needs no escaping."
                     valid_status = AbstractRequirements.VALID_STATUS.valid
                 }
+
+                SwReq sw_req_markdown_render_plantuml {
+                    description = "When the `--render-plantuml` option is given, the software shall replace fenced code blocks tagged `plantuml` in the Markdown output with SVG image references (`![](plantuml_<hash>.svg)`). The generated SVG file shall be copied to the output folder. If PlantUML is not available, the block shall be replaced by a `[PlantUML error: ...]` paragraph instead of failing the conversion. Without the option, plantuml fenced code blocks shall be passed through unchanged."
+                    verification_criteria = "Verify that with `--render-plantuml`, a plantuml fenced code block is replaced by an SVG image reference and the SVG file is present in the output folder. Verify that without the option the block is passed through unchanged. Verify that an unavailable PlantUML yields a `[PlantUML error: ...]` paragraph."
+                    valid_status = AbstractRequirements.VALID_STATUS.valid
+                }
             }
         }
 
@@ -413,7 +426,7 @@ section "SW Requirements" {
 
             SwReq sw_req_rst_out_folder {
                 description = "The reStructuredText converter shall create the converted files in the specified output folder."
-                verification_criteria = "Verify by specifing an output folder, that doesn't exist. It must exist after the conversion."
+                verification_criteria = "Verify by specifying an output folder, that doesn't exist. It must exist after the conversion."
                 valid_status = AbstractRequirements.VALID_STATUS.valid
             }
 
@@ -716,8 +729,8 @@ section "SW Requirements" {
             }
 
             SwReq sw_req_plantuml {
-                description = "The software shall support the conversion of a PlantUML diagram to a propriate image format."
-                verification_criteria = "Verify by converting a PlantUML diagram into a propriate image format."
+                description = "The software shall support the conversion of a PlantUML diagram to an appropriate image format."
+                verification_criteria = "Verify by converting a PlantUML diagram into an appropriate image format."
                 valid_status = AbstractRequirements.VALID_STATUS.valid
             }
         }

--- a/trlc/swe-req/swe-req.trlc
+++ b/trlc/swe-req/swe-req.trlc
@@ -476,6 +476,12 @@ section "SW Requirements" {
                     verification_criteria = "Verify by using strings in Markdown format according to GitHub Flavored Markdown spec, that are converted."
                     valid_status = AbstractRequirements.VALID_STATUS.valid
                 }
+
+                SwReq sw_req_rst_render_plantuml {
+                    description = "The software shall render fenced code blocks tagged `plantuml` inside Markdown (CommonMark or GFM) requirement attributes as SVG images in the reStructuredText output. The generated SVG file shall be copied to the output folder and referenced via a `.. image::` directive. If PlantUML is not available, the block shall be replaced by a `[PlantUML error: ...]` paragraph instead of failing the conversion."
+                    verification_criteria = "Verify that a Markdown requirement attribute containing a fenced ```plantuml``` code block produces a reStructuredText `.. image::` directive referencing an SVG file present in the output folder, and that omitting the PlantUML configuration yields a `[PlantUML error: ...]` paragraph."
+                    valid_status = AbstractRequirements.VALID_STATUS.valid
+                }
             }
         }
 
@@ -679,6 +685,12 @@ section "SW Requirements" {
                 SwReq sw_req_docx_render_gfm {
                     description = "The software shall convert strings in [GitHub Flavored Markdown spec v0.29-gfm](https://github.github.com/gfm) Markdown format to docx format if specified in the render configuration."
                     verification_criteria = "Verify by using strings in Markdown format according to GitHub Flavored Markdown spec, that are converted."
+                    valid_status = AbstractRequirements.VALID_STATUS.valid
+                }
+
+                SwReq sw_req_docx_render_plantuml {
+                    description = "The software shall render fenced code blocks tagged `plantuml` inside Markdown (CommonMark or GFM) requirement attributes as embedded PNG images in the docx output. If PlantUML is not available, the block shall be replaced by a `[PlantUML error: ...]` paragraph instead of failing the conversion."
+                    verification_criteria = "Verify that a Markdown requirement attribute containing a fenced ```plantuml``` code block produces an embedded image in the docx output, and that omitting the PlantUML configuration yields a `[PlantUML error: ...]` paragraph."
                     valid_status = AbstractRequirements.VALID_STATUS.valid
                 }
             }

--- a/trlc/swe-req/swe-req.trlc
+++ b/trlc/swe-req/swe-req.trlc
@@ -617,6 +617,12 @@ section "SW Requirements" {
                     verification_criteria = "Verify that a GFM attribute configured with `tableOptions` containing `border` and `headingStyle` generates a ReqIF XHTML `<table>` with the specified `style` and `<th>` cells with the specified `style`."
                     valid_status = AbstractRequirements.VALID_STATUS.valid
                 }
+
+                SwReq sw_req_reqif_render_plantuml {
+                    description = "The software shall render fenced code blocks tagged `plantuml` inside Markdown (CommonMark or GFM) requirement attributes as embedded SVG images in the ReqIF XHTML output. The generated SVG file shall be copied to the output folder (or bundled into the .reqifz archive) and referenced from the XHTML via an `<object>` element with `type=\"image/svg+xml\"` and `data` set to the SVG file's local name. If PlantUML is not available, the block shall be replaced by a `[PlantUML error: ...]` paragraph instead of failing the conversion."
+                    verification_criteria = "Verify that a Markdown requirement attribute containing a fenced ```plantuml``` code block produces a ReqIF XHTML `<object type=\"image/svg+xml\">` element, that the referenced SVG file is present in the output folder, and that omitting the PlantUML configuration yields a `[PlantUML error: ...]` paragraph."
+                    valid_status = AbstractRequirements.VALID_STATUS.valid
+                }
             }
         }
 

--- a/trlc/swe-test/swe-test.trlc
+++ b/trlc/swe-test/swe-test.trlc
@@ -360,6 +360,20 @@ section "SW Test Cases" {
             verifies = [SwRequirements.sw_req_reqif_render_path]
         }
 
+        SwTestCase tc_reqif_render_plantuml {
+            description = '''This test case checks whether a fenced ```plantuml``` code block inside a Markdown requirement attribute is
+             rendered as an XHTML <object type="image/svg+xml"> element in the generated ReqIF output and that the referenced SVG file
+             is written to the output folder.'''
+            verifies = [SwRequirements.sw_req_reqif_render_plantuml, SwRequirements.sw_req_plantuml]
+        }
+
+        SwTestCase tc_reqif_render_plantuml_error {
+            description = '''This test case checks whether a fenced ```plantuml``` code block is replaced by a [PlantUML error: ...]
+             paragraph in the generated ReqIF output when the PLANTUML environment variable is not configured, so the conversion
+             does not fail.'''
+            verifies = [SwRequirements.sw_req_reqif_render_plantuml]
+        }
+
         SwTestCase tc_reqif_enum {
             description = "This test case checks whether a TRLC enumeration attribute is converted to a DATATYPE-DEFINITION-ENUMERATION with 0-based consecutive ENUM-VALUE keys and emitted as ATTRIBUTE-VALUE-ENUMERATION in the spec-object."
             verifies = [SwRequirements.sw_req_reqif_enum, SwRequirements.sw_req_reqif_enum_key_order]

--- a/trlc/swe-test/swe-test.trlc
+++ b/trlc/swe-test/swe-test.trlc
@@ -297,6 +297,19 @@ section "SW Test Cases" {
              when the render configuration is set to "gfm".'''
             verifies = [SwRequirements.sw_req_rst_render_gfm]
         }
+
+        SwTestCase tc_rst_render_plantuml {
+            description = '''This test case checks whether a fenced ```plantuml``` code block inside a Markdown requirement attribute is
+             rendered as a reStructuredText ``.. image::`` directive referencing an SVG file written to the output folder.'''
+            verifies = [SwRequirements.sw_req_rst_render_plantuml, SwRequirements.sw_req_plantuml]
+        }
+
+        SwTestCase tc_rst_render_plantuml_error {
+            description = '''This test case checks whether a fenced ```plantuml``` code block is replaced by a [PlantUML error: ...]
+             paragraph in the generated RST output when the PLANTUML environment variable is not configured, so the conversion
+             does not fail.'''
+            verifies = [SwRequirements.sw_req_rst_render_plantuml]
+        }
     }
 
     section "ReqIF" {
@@ -430,6 +443,13 @@ section "SW Test Cases" {
         SwTestCase tc_docx_render_gfm {
             description = "This test case checks whether GitHub Flavored Markdown content in requirement attributes is rendered correctly when the render configuration is set to \"gfm\"."
             verifies = [SwRequirements.sw_req_docx_render_gfm]
+        }
+
+        SwTestCase tc_docx_render_plantuml {
+            description = '''This test case checks whether a fenced ```plantuml``` code block inside a Markdown requirement attribute is
+             rendered as an embedded PNG image in the docx output, or replaced by a [PlantUML error: ...] paragraph if PlantUML is
+             not available.'''
+            verifies = [SwRequirements.sw_req_docx_render_plantuml, SwRequirements.sw_req_plantuml]
         }
     }
 

--- a/trlc/swe-test/swe-test.trlc
+++ b/trlc/swe-test/swe-test.trlc
@@ -196,6 +196,18 @@ section "SW Test Cases" {
              when the render configuration is set to "gfm".'''
             verifies = [SwRequirements.sw_req_markdown_render_gfm, SwRequirements.sw_req_markdown_string_format]
         }
+
+        SwTestCase tc_markdown_render_plantuml {
+            description = '''This test case checks whether a fenced ```plantuml``` code block inside a Markdown requirement attribute is
+             replaced by an SVG image reference when --render-plantuml is given, and that the SVG file is written to the output folder.'''
+            verifies = [SwRequirements.sw_req_markdown_render_plantuml, SwRequirements.sw_req_cli_render_plantuml, SwRequirements.sw_req_plantuml]
+        }
+
+        SwTestCase tc_markdown_render_plantuml_error {
+            description = '''This test case checks whether a fenced ```plantuml``` code block is replaced by a [PlantUML error: ...]
+             paragraph in the Markdown output when --render-plantuml is given but PlantUML is not available.'''
+            verifies = [SwRequirements.sw_req_markdown_render_plantuml]
+        }
     }
 
     section "reStructuredText" {


### PR DESCRIPTION
Adds support for rendering ` ```plantuml ``` ` fenced code blocks in Markdown-formatted
requirement attributes as embedded images in all output formats.

| Format   | Output                                                                      |
| -------- | --------------------------------------------------------------------------- |
| docx     | Embedded PNG via `add_picture()`                                            |
| rst      | SVG file copied alongside output, referenced via `.. image::`              |
| reqif    | SVG file copied alongside output, referenced via XHTML `<object>`          |
| markdown | SVG file copied alongside output, referenced via `![]()` — opt-in via `--render-plantuml` |

The Markdown format uses an opt-in flag because not all Markdown renderers support
PlantUML natively (e.g. GitHub renders it as a plain code block, while GitLab renders
it natively).

In all formats, if PlantUML is not configured, the block is replaced by a
`[PlantUML error: ...]` paragraph instead of failing the conversion.

Full traceability maintained: requirements, architecture specs, and test cases added
for each format.

Closes #127