### PR TITLE
Adjust deploy workflow for releases.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,8 @@ jobs:
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./tools/deployDoc/build/html/_static/version_selector_data.js
+          publish_dir: ./tools/deployDoc/build/html/_static
+          exclude_assets: '!version_selector_data.js' # Exclude all files and directories except version_selector_data.js.
           destination_dir: ./versions
 
   # Build the package distribution and upload it as a workflow artifact.


### PR DESCRIPTION
Fixes #146
The action treated the given path as a dir.
Now working with the parent directory and an exclusion glob pattern.